### PR TITLE
Different package id for android debug builds and different name

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -66,9 +66,11 @@ android {
     buildTypes {
         debug {
             applicationIdSuffix ".dev" // Appends a suffix to debug builds to prevent conflicts with release version
+            resValue 'string', 'app_name', '"Mona (dev)"'
         }
         release {
             signingConfig signingConfigs.release
+            resValue 'string', 'app_name', '"Mona"'
         }
     }
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <application
-        android:label="Mona"
+        android:label="@string/app_name"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity


### PR DESCRIPTION
I added a suffix to the package id of android debug builds so they can be installed next to release builds.

I also changed the name of the app for debug builds so it's easier to differentiate debug and release versions.