### PR TITLE
fix: toggle for auto update setting in wrong state

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Take control of your hormonal health with Mona, the fully local, open-source app
 Mona is available for both Android and iOS. 
 
 - **Android:** [Download the latest APK](https://github.com/delia-cheminot/mona-hrt/releases/tag/latest)
-- **iOS:** [Join the TestFlight Beta](https://testflight.apple.com/join/ersXvycy) or [JDownload on the App Store](https://apps.apple.com/app/mona-hrt-journal/id6757274628)
+- **iOS:** [Join the TestFlight Beta](https://testflight.apple.com/join/ersXvycy) or [Download on the App Store](https://apps.apple.com/app/mona-hrt-journal/id6757274628)
 
 ---
 

--- a/lib/ui/views/home/settings/settings_page.dart
+++ b/lib/ui/views/home/settings/settings_page.dart
@@ -18,6 +18,7 @@ class SettingsPage extends StatefulWidget {
 class _SettingsPageState extends State<SettingsPage>
     with WidgetsBindingObserver {
   late bool _notificationsEnabled;
+  late bool _autoCheckUpdatesEnabled;
   bool _permissionGranted = true;
   late PreferencesService _preferencesService;
 
@@ -28,6 +29,7 @@ class _SettingsPageState extends State<SettingsPage>
     _preferencesService =
         Provider.of<PreferencesService>(context, listen: false);
     _notificationsEnabled = _preferencesService.notificationsEnabled;
+    _autoCheckUpdatesEnabled = _preferencesService.autoCheckUpdatesEnabled;
     _checkPermission();
   }
 
@@ -61,6 +63,14 @@ class _SettingsPageState extends State<SettingsPage>
 
     setState(() {
       _notificationsEnabled = value;
+    });
+  }
+
+  Future<void> _toggleAutoCheckUpdates(bool value) async {
+    await _preferencesService.setAutoCheckUpdatesEnabled(value);
+
+    setState(() {
+      _autoCheckUpdatesEnabled = value;
     });
   }
 
@@ -114,10 +124,8 @@ class _SettingsPageState extends State<SettingsPage>
               title: const Text('Auto-Update'),
               subtitle: const Text(
                   'Automatically check new updates when app is launched'),
-              value: _preferencesService.autoCheckUpdatesEnabled,
-              onChanged: (bool value) {
-                _preferencesService.setAutoCheckUpdatesEnabled(value);
-              },
+              value: _autoCheckUpdatesEnabled,
+              onChanged: _toggleAutoCheckUpdates,
             ),
             ListTile(
               title: const Text('Check for Updates'),


### PR DESCRIPTION
toggle did not reflect updated state after update, not allowing update of the setting unless page reload