### PR TITLE
chore: added/updated keys for iOS source

### DIFF
--- a/ios_source.json
+++ b/ios_source.json
@@ -30,7 +30,7 @@
         "https://i.imgur.com/vuSqW2l.png",
         "https://i.imgur.com/5cjzlB0.png"
       ],
-      "downloadURL": "https://github.com/delia-cheminot/mona-hrt/releases/download/v1.3.0/mona.ipa",
+      "downloadURL": "https://github.com/delia-cheminot/mona-hrt/releases/download/v1.4.0/mona.ipa",
       "size": 9556599,
       "version": "1.4.0",
       "versionDate": "2026-03-19T15:52:18Z",


### PR DESCRIPTION
~~Note: this is missing screenshots, which I would like to add from the [App Store](https://apps.apple.com/app/mona-hrt-journal/id6757274628) or [TestFlight](https://testflight.apple.com/join/ersXvycy) listings. Unfortunately, Apple does not (very easily) provide direct downloads for these screenshots in full high-quality.~~

~~You can also just add these yourself though - upload them somewhere and then complete the array in both `screenshots` (where a 9:19.5 aspect ratio is expected; you can specify a different width and height but you lose the rounding) and `screenshotURLs` (where a 9:16 aspect ratio is expected, and others are stretched to fill). [Ref 1](https://faq.altstore.io/developers/make-a-source), [ref 2](http://web.archive.org/web/20230419105856/https://faq.altstore.io/sources/make-a-source).~~ *[Edit: Screenshots have now been added.]*

Related: https://github.com/SideStore/SideStore/pull/1210. Still need to test this but I have no reason to believe it won't work.