### PR TITLE
fix: disable dependency metadata block

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,3 +16,10 @@ subprojects {
 tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }
+
+android {
+    dependenciesInfo {
+        includeInApk = false
+        includeInBundle = false
+    }
+}


### PR DESCRIPTION
A few stores we've been discussing submitting to specifically request this be disabled. Only Google is able to read what the block contains, so no one else can verify what is inside of it. It has no use to us.