### PR TITLE
fix: pin Flutter version

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,3 +1,3 @@
 {
-  "flutterSdkVersion": "stable"
+  "flutterSdkVersion": "3.41.5"
 }

--- a/.fvmrc
+++ b/.fvmrc
@@ -1,3 +1,3 @@
 {
-  "flutter": "stable"
+  "flutter": "3.41.5"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -44,10 +44,7 @@ app.*.map.json
 /android/app/profile
 /android/app/release
 
-# FVM Version Cache
-.fvm/versions
-.fvm/flutter_sdk
-.fvm/release
-.fvm/version
-
 android/.kotlin/
+
+# FVM Version Cache
+.fvm/

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ version: 1.3.0+1
 
 environment:
   sdk: ">=3.3.4 <4.0.0"
+  flutter: "^3.41.5"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/setup_dev.sh
+++ b/setup_dev.sh
@@ -5,7 +5,7 @@ echo -e "Preparing local repository for development...\n"
 
 if ! command -v dart &> /dev/null; then
     echo -e "Error: Dart is not installed or not in your PATH.\n"
-    echo "FVM requires Dart to be installed initially.\n - Please install Flutter globally first.\n - If Flutter is install check 'flutter doctor' for more informations.\n"
+    echo "FVM requires Dart to be installed initially.\n - Please install Flutter globally first.\n - If Flutter is installed, check 'flutter doctor' for more information.\n"
     exit 1
 fi
 
@@ -49,8 +49,8 @@ fi
 
 export PATH="$PATH:$PUB_CACHE_BIN"
 
-echo -e "\nConfiguring project to use the latest stable Flutter SDK..."
-fvm use stable
+echo -e "\nConfiguring project to use the correct Flutter SDK..."
+fvm use 3.41.5
 
 echo -e "\nFetching the latest dependencies..."
 fvm flutter pub get


### PR DESCRIPTION
The latest stable version as of writing is 3.41.5. We have had issues with dependencies breaking on newer versions of Flutter in the past. So, instead of always assuming the latest stable will work, we pin the Flutter version and update manually. Some stores also requested we use a pinned Flutter version.

For an update later down the road, all that needs to be done is an update of pubspec.yaml and setup_dev.sh. Then run setup_dev.sh and the FVM files will update accordingly.