### PR TITLE
fix: init notifications after app starts

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -2,6 +2,7 @@ import 'package:dynamic_system_colors/dynamic_system_colors.dart';
 import 'package:flutter/material.dart';
 import 'package:mona/controllers/notification_scheduler.dart';
 import 'package:mona/data/providers/medication_schedule_provider.dart';
+import 'package:mona/services/notification_service.dart';
 import 'package:mona/services/preferences_service.dart';
 import 'package:provider/provider.dart';
 import 'ui/views/main_page.dart';
@@ -36,7 +37,9 @@ class _MonaAppState extends State<MonaApp> with WidgetsBindingObserver {
     WidgetsBinding.instance.addObserver(this);
     _lastTimeZone = DateTime.now().timeZoneOffset.toString();
 
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      await NotificationService().initialize();
+      if (!mounted) return;
       _medicationScheduleProvider = context.read<MedicationScheduleProvider>();
       _preferencesService = context.read<PreferencesService>();
       _medicationScheduleProvider.addListener(_regenerateNotifications);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,7 +14,6 @@ import 'package:flutter/services.dart';
 import 'package:mona/data/providers/medication_intake_provider.dart';
 import 'package:mona/data/providers/medication_schedule_provider.dart';
 import 'package:mona/data/providers/supply_item_provider.dart';
-import 'package:mona/services/notification_service.dart';
 import 'package:mona/services/preferences_service.dart';
 import 'package:provider/provider.dart';
 import 'app.dart';
@@ -22,7 +21,6 @@ import 'app.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  await NotificationService().initialize();
   final preferencesService = await PreferencesService.init();
 
   SystemChrome.setSystemUIOverlayStyle(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
fixes a freeze at splash screen caused by the notification service failing to init at app startup. moved the init to once the ui is drawn.

Related to issue(s): # (issue)

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)

### Screenshots (if appropriate):
