### PR TITLE
v1.5.1

### DIFF
--- a/lib/ui/widgets/forms/form_date_field.dart
+++ b/lib/ui/widgets/forms/form_date_field.dart
@@ -42,7 +42,7 @@ class FormDateField extends BaseFormField {
     );
 
     if (picked != null) {
-      onChanged(Date(picked.toUtc()));
+      onChanged(Date(DateTime.utc(picked.year, picked.month, picked.day)));
     }
   }
 }


### PR DESCRIPTION
Fixed: date picker now opens on the correct date. A quick fix for an issue where the date picker would snap back to today instead of staying on the selected date.