### PR TITLE
fix: replace timezone data import with latest_all

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -5,7 +5,6 @@ import 'package:mona/data/providers/medication_schedule_provider.dart';
 import 'package:mona/services/notification_service.dart';
 import 'package:mona/services/preferences_service.dart';
 import 'package:provider/provider.dart';
-import 'package:timezone/data/latest.dart' as tz;
 import 'ui/views/main_page.dart';
 
 class MonaApp extends StatefulWidget {
@@ -39,7 +38,6 @@ class _MonaAppState extends State<MonaApp> with WidgetsBindingObserver {
     _lastTimeZone = DateTime.now().timeZoneOffset.toString();
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      tz.initializeTimeZones();
       await NotificationService().initialize();
       if (!mounted) return;
       _medicationScheduleProvider = context.read<MedicationScheduleProvider>();

--- a/lib/data/model/blood_test.dart
+++ b/lib/data/model/blood_test.dart
@@ -1,6 +1,7 @@
 import 'package:decimal/decimal.dart';
 import 'package:mona/data/model/date.dart';
 import 'package:mona/util/string_parsing.dart';
+import 'package:mona/util/timezone_location.dart';
 import 'package:mona/util/validators.dart';
 import 'package:timezone/timezone.dart' as tz;
 
@@ -34,8 +35,10 @@ class BloodTest {
     );
   }
 
-  DateTime get localDateTime =>
-      tz.TZDateTime.from(dateTime, tz.getLocation(timeZone));
+  DateTime get localDateTime {
+    final location = timeZoneLocation(timeZone);
+    return tz.TZDateTime.from(dateTime, location);
+  }
 
   Date get localDate => Date.fromDateTime(localDateTime);
 

--- a/lib/data/model/medication_intake.dart
+++ b/lib/data/model/medication_intake.dart
@@ -7,6 +7,7 @@ import 'package:mona/data/model/date.dart';
 import 'package:mona/data/model/ester.dart';
 import 'package:mona/data/model/molecule.dart';
 import 'package:mona/util/string_parsing.dart';
+import 'package:mona/util/timezone_location.dart';
 import 'package:mona/util/validators.dart';
 import 'package:timezone/timezone.dart' as tz;
 
@@ -122,7 +123,7 @@ class MedicationIntake {
   DateTime? get takenLocalDateTime {
     if (takenDateTime == null) return null;
 
-    final location = tz.getLocation(takenTimeZone!);
+    final location = timeZoneLocation(takenTimeZone!);
     return tz.TZDateTime.from(takenDateTime!, location);
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,10 +17,12 @@ import 'package:mona/data/providers/medication_schedule_provider.dart';
 import 'package:mona/data/providers/supply_item_provider.dart';
 import 'package:mona/services/preferences_service.dart';
 import 'package:provider/provider.dart';
+import 'package:timezone/data/latest_all.dart' as tzdata;
 import 'app.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  tzdata.initializeTimeZones();
 
   final preferencesService = await PreferencesService.init();
 

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -4,7 +4,7 @@ import 'dart:math';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:mona/util/string_parsing.dart';
-import 'package:timezone/data/latest.dart' as tz;
+import 'package:timezone/data/latest_all.dart' as tzdata;
 import 'package:timezone/timezone.dart' as tz;
 
 class NotificationService {
@@ -36,7 +36,7 @@ class NotificationService {
   Future<void> initialize() async {
     if (_initialized) return;
 
-    tz.initializeTimeZones();
+    tzdata.initializeTimeZones();
     final TimezoneInfo currentTimeZone =
         await FlutterTimezone.getLocalTimezone();
     tz.setLocalLocation(tz.getLocation(currentTimeZone.identifier));

--- a/lib/util/timezone_location.dart
+++ b/lib/util/timezone_location.dart
@@ -1,0 +1,15 @@
+import 'package:timezone/timezone.dart' as tz;
+
+/// Resolves [id] with [tz.getLocation], falling back to [Etc/UTC] when the name
+/// is missing from the embedded database (or the DB is not initialized).
+tz.Location timeZoneLocation(String id) {
+  try {
+    return tz.getLocation(id);
+  } on tz.LocationNotFoundException {
+    try {
+      return tz.getLocation('Etc/UTC');
+    } on tz.LocationNotFoundException {
+      return tz.UTC;
+    }
+  }
+}

--- a/test/controllers/notification_scheduler_test.dart
+++ b/test/controllers/notification_scheduler_test.dart
@@ -11,7 +11,7 @@ import 'package:mona/data/model/molecule.dart';
 import 'package:mona/data/providers/medication_schedule_provider.dart';
 import 'package:mona/services/notification_service.dart';
 import 'package:mona/services/preferences_service.dart';
-import 'package:timezone/data/latest.dart' as tz;
+import 'package:timezone/data/latest_all.dart' as tz;
 import 'package:timezone/timezone.dart' as tz;
 
 @GenerateNiceMocks([

--- a/test/data/model/date_test.dart
+++ b/test/data/model/date_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/intl.dart';
 import 'package:mona/data/model/date.dart';
-import 'package:timezone/data/latest.dart' as tz;
+import 'package:timezone/data/latest_all.dart' as tz;
 import 'package:timezone/timezone.dart';
 
 void main() {

--- a/test/data/model/medication_intake_test.dart
+++ b/test/data/model/medication_intake_test.dart
@@ -5,7 +5,7 @@ import 'package:mona/data/model/date.dart';
 import 'package:mona/data/model/ester.dart';
 import 'package:mona/data/model/medication_intake.dart';
 import 'package:mona/data/model/molecule.dart';
-import 'package:timezone/data/latest.dart' as tz;
+import 'package:timezone/data/latest_all.dart' as tz;
 
 void main() {
   setUpAll(() {
@@ -148,6 +148,21 @@ void main() {
 
         // Assert
         expect(takenLocalDateTime?.hour, 10);
+      });
+
+      test(
+          'takenLocalDateTime works with timezone names not in the reduced database',
+          () {
+        final intake = MedicationIntake(
+          scheduledDateTime: DateTime.utc(2024, 6, 15, 10, 0),
+          dose: Decimal.one,
+          takenDateTime: DateTime.utc(2024, 6, 15, 10, 0),
+          takenTimeZone: 'Europe/Amsterdam', // missing from package:timezone latest.dart
+          molecule: KnownMolecules.estradiol,
+          administrationRoute: AdministrationRoute.oral,
+        );
+
+        expect(intake.takenLocalDate, Date(DateTime.utc(2024, 6, 15)));
       });
 
       test(

--- a/test/data/providers/blood_test_provider_test.dart
+++ b/test/data/providers/blood_test_provider_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mona/data/model/blood_test.dart';
 import 'package:mona/data/model/date.dart';
 import 'package:mona/data/providers/blood_test_provider.dart';
-import 'package:timezone/data/latest.dart' as tz;
+import 'package:timezone/data/latest_all.dart' as tz;
 import 'generic_repository_mock.dart';
 
 void main() {

--- a/test/data/providers/medication_intake_provider_test.dart
+++ b/test/data/providers/medication_intake_provider_test.dart
@@ -4,7 +4,7 @@ import 'package:mona/data/model/administration_route.dart';
 import 'package:mona/data/model/medication_intake.dart';
 import 'package:mona/data/model/molecule.dart';
 import 'package:mona/data/providers/medication_intake_provider.dart';
-import 'package:timezone/data/latest.dart' as tz;
+import 'package:timezone/data/latest_all.dart' as tz;
 import 'generic_repository_mock.dart';
 
 void main() {

--- a/test/services/notification_service_test.dart
+++ b/test/services/notification_service_test.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mona/services/notification_service.dart';
-import 'package:timezone/data/latest.dart' as tzdata;
+import 'package:timezone/data/latest_all.dart' as tzdata;
 import 'package:timezone/timezone.dart' as tz;
 
 class FakeFlutterLocalNotificationsPlugin

--- a/test/util/timezone_location_test.dart
+++ b/test/util/timezone_location_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mona/util/timezone_location.dart';
+import 'package:timezone/data/latest_all.dart' as tzdata;
+
+void main() {
+  setUpAll(tzdata.initializeTimeZones);
+
+  test('known IANA id returns that location', () {
+    final loc = timeZoneLocation('Europe/Paris');
+    expect(loc.name, 'Europe/Paris');
+  });
+
+  test('unknown id falls back to Etc/UTC', () {
+    final loc = timeZoneLocation('Not/ARealZone');
+    expect(loc.name, 'Etc/UTC');
+  });
+}


### PR DESCRIPTION
fixes #112 

### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Problem
After the first medication intake, most tabs went blank (Supplies still worked). Levels broke once the chart had enough data.

## Cause
- Intakes store takenTimeZone from the device (e.g. Europe/Amsterdam on Android for the Netherlands).
- MedicationIntake.takenLocalDateTime / BloodTest.localDateTime call tz.getLocation(storedId) on the database loaded by package:timezone/data/latest.dart.
- That build uses a reduced IANA set: some IDs the OS returns are not in the embedded DB, so getLocation throws → Flutter build errors → empty UI.
- The same lookup runs in NotificationService.initialize() (setLocalLocation(getLocation(deviceId))), so startup could also hit the same exception.

## Fix
- Load the full timezone database everywhere we call initializeTimeZones(): switch imports from timezone/data/latest.dart to timezone/data/latest_all.dart (main.dart, notification_service.dart, and tests) so OS-reported zone names resolve.
- Call initializeTimeZones() in main() right after WidgetsFlutterBinding.ensureInitialized(), before runApp, so the DB is ready before any widget uses timezone lookups (avoids relying only on a later async init).
- NotificationService: use tzdata for latest_all and tz for package:timezone/timezone.dart so we don’t merge two libraries under the same prefix.
- Regression test: in medication_intake_test.dart, an intake with Europe/Amsterdam must resolve takenLocalDate without throwing (that ID was missing from latest.dart).
 
## Trade-off
latest_all increases app size vs latest, in exchange for matching real device zone IDs. 