### PR TITLE
feat: allow switching between common units

### DIFF
--- a/lib/data/model/blood_test.dart
+++ b/lib/data/model/blood_test.dart
@@ -1,5 +1,5 @@
-import 'package:decimal/decimal.dart';
 import 'package:mona/data/model/date.dart';
+import 'package:mona/data/model/units.dart';
 import 'package:mona/l10n/app_localizations.dart';
 import 'package:mona/util/string_parsing.dart';
 import 'package:mona/util/timezone_location.dart';
@@ -10,8 +10,8 @@ class BloodTest {
   final int id;
   final DateTime dateTime;
   final String timeZone;
-  final Decimal? estradiolLevels;
-  final Decimal? testosteroneLevels;
+  final UnitValue<EstradiolUnit>? estradiolLevels;
+  final UnitValue<TestosteroneUnit>? testosteroneLevels;
 
   BloodTest({
     int? id,
@@ -26,14 +26,28 @@ class BloodTest {
   }
 
   factory BloodTest.fromMap(Map<String, Object?> map) {
+    final estradiolLevels = (map['estradiolLevels'] as String?).toDecimalOrNull;
+    final estradiolUnitName = map['estradiolUnit'] as String?;
+    final estradiolUnit = estradiolUnitName != null
+        ? EstradiolUnit.parse(estradiolUnitName)
+        : EstradiolUnit.pg_mL;
+    final testosteroneLevels =
+        (map['testosteroneLevels'] as String?).toDecimalOrNull;
+    final testosteroneUnitName = map['testosteroneUnit'] as String?;
+    final testosteroneUnit = testosteroneUnitName != null
+        ? TestosteroneUnit.parse(testosteroneUnitName)
+        : TestosteroneUnit.ng_dL;
+
     return BloodTest(
-      id: map['id'] as int?,
-      dateTime: (map['dateTime'] as String).toDateTime,
-      timeZone: map['timeZone'] as String,
-      estradiolLevels: (map['estradiolLevels'] as String?).toDecimalOrNull,
-      testosteroneLevels:
-          (map['testosteroneLevels'] as String?).toDecimalOrNull,
-    );
+        id: map['id'] as int?,
+        dateTime: (map['dateTime'] as String).toDateTime,
+        timeZone: map['timeZone'] as String,
+        estradiolLevels: estradiolLevels != null
+            ? UnitValue(estradiolLevels, estradiolUnit)
+            : null,
+        testosteroneLevels: testosteroneLevels != null
+            ? UnitValue(testosteroneLevels, testosteroneUnit)
+            : null);
   }
 
   DateTime get localDateTime {
@@ -47,8 +61,8 @@ class BloodTest {
     int? id,
     DateTime? dateTime,
     String? timeZone,
-    Decimal? estradiolLevels,
-    Decimal? testosteroneLevels,
+    UnitValue<EstradiolUnit>? estradiolLevels,
+    UnitValue<TestosteroneUnit>? testosteroneLevels,
   }) {
     return BloodTest(
       id: id ?? this.id,
@@ -64,8 +78,10 @@ class BloodTest {
       'id': id,
       'dateTime': dateTime.toIso8601String(),
       'timeZone': timeZone,
-      'estradiolLevels': estradiolLevels?.toString(),
-      'testosteroneLevels': testosteroneLevels?.toString(),
+      'estradiolLevels': estradiolLevels?.value.toString(),
+      'estradiolUnit': estradiolLevels?.unit.toString(),
+      'testosteroneLevels': testosteroneLevels?.value.toString(),
+      'testosteroneUnit': testosteroneLevels?.unit.toString(),
     };
   }
 
@@ -82,5 +98,5 @@ class BloodTest {
 
   @override
   int get hashCode => id.hashCode;
-  // coverage:ignore-end
+// coverage:ignore-end
 }

--- a/lib/data/model/blood_test.dart
+++ b/lib/data/model/blood_test.dart
@@ -30,23 +30,23 @@ class BloodTest {
     final estradiolUnitName = map['estradiolUnit'] as String?;
     final estradiolUnit = estradiolUnitName != null
         ? EstradiolUnit.parse(estradiolUnitName)
-        : EstradiolUnit.pg_mL;
+        : null;
     final testosteroneLevels =
         (map['testosteroneLevels'] as String?).toDecimalOrNull;
     final testosteroneUnitName = map['testosteroneUnit'] as String?;
     final testosteroneUnit = testosteroneUnitName != null
         ? TestosteroneUnit.parse(testosteroneUnitName)
-        : TestosteroneUnit.ng_dL;
+        : null;
 
     return BloodTest(
         id: map['id'] as int?,
         dateTime: (map['dateTime'] as String).toDateTime,
         timeZone: map['timeZone'] as String,
         estradiolLevels: estradiolLevels != null
-            ? UnitValue(estradiolLevels, estradiolUnit)
+            ? UnitValue(estradiolLevels, estradiolUnit!)
             : null,
         testosteroneLevels: testosteroneLevels != null
-            ? UnitValue(testosteroneLevels, testosteroneUnit)
+            ? UnitValue(testosteroneLevels, testosteroneUnit!)
             : null);
   }
 

--- a/lib/data/model/graph_calculator.dart
+++ b/lib/data/model/graph_calculator.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 
 import 'package:fl_chart/fl_chart.dart';
 import 'package:mona/data/model/ester.dart';
+import 'package:mona/data/model/units.dart';
 import 'package:mona/data/providers/medication_intake_provider.dart';
 
 class GraphCalculator {
@@ -79,14 +80,16 @@ class GraphCalculator {
   }
 
   double totalConcentrationAtTime(
-      double t, Map<int, GraphIntake> daysAndIntakes) {
+      double t, Map<int, GraphIntake> daysAndIntakes, EstradiolUnit unit) {
     if (daysAndIntakes.isEmpty) return 0.0;
-    return daysAndIntakes.entries
+    final concentration = daysAndIntakes.entries
         .map((e) => _singleInjectionConcentration(t, e.key, e.value))
         .fold(0.0, (sum, val) => sum + val);
+    return EstradiolUnit.pg_mL.convert(concentration, unit).toDouble();
   }
 
-  List<FlSpot> generateFlSpots(Map<int, GraphIntake> daysAndIntakes,
+  List<FlSpot> generateFlSpots(
+      Map<int, GraphIntake> daysAndIntakes, EstradiolUnit unit,
       {double tMin = 0, int numPoints = 1000}) {
     if (daysAndIntakes.isEmpty) return <FlSpot>[];
 
@@ -96,7 +99,7 @@ class GraphCalculator {
 
     for (int i = 0; i <= numPoints; i++) {
       double t = tMin + ((tMax - tMin) / numPoints) * i;
-      double concentration = totalConcentrationAtTime(t, daysAndIntakes);
+      double concentration = totalConcentrationAtTime(t, daysAndIntakes, unit);
       points.add(math.Point(t, concentration));
     }
 

--- a/lib/data/model/graph_calculator.dart
+++ b/lib/data/model/graph_calculator.dart
@@ -1,5 +1,6 @@
 import 'dart:math' as math;
 
+import 'package:decimal/decimal.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:mona/data/model/ester.dart';
 import 'package:mona/data/model/units.dart';
@@ -85,7 +86,9 @@ class GraphCalculator {
     final concentration = daysAndIntakes.entries
         .map((e) => _singleInjectionConcentration(t, e.key, e.value))
         .fold(0.0, (sum, val) => sum + val);
-    return EstradiolUnit.pg_mL.convert(concentration, unit).toDouble();
+    return EstradiolUnit.pg_mL
+        .convert(Decimal.parse(concentration.toStringAsFixed(2)), unit)
+        .toDouble();
   }
 
   List<FlSpot> generateFlSpots(

--- a/lib/data/model/units.dart
+++ b/lib/data/model/units.dart
@@ -1,0 +1,114 @@
+// ignore_for_file: constant_identifier_names
+import 'package:decimal/decimal.dart';
+
+abstract interface class Unit<T> implements Enum {
+  final String name;
+
+  Unit(this.name);
+
+  num convert(num value, T into);
+}
+
+enum EstradiolUnit implements Unit<EstradiolUnit> {
+  pg_mL("pg/mL"),
+  pmol_L("pmol/L");
+
+  @override
+  final String name;
+
+  const EstradiolUnit(this.name);
+
+  @override
+  num convert(num value, EstradiolUnit into) {
+    if (into == this) return value;
+    return switch (into) {
+      EstradiolUnit.pg_mL => value / 3.671,
+      EstradiolUnit.pmol_L => value * 3.671
+    };
+  }
+
+  @override
+  String toString() {
+    return name;
+  }
+
+  factory EstradiolUnit.parse(String value) {
+    return EstradiolUnit.values.firstWhere((unit) => unit.name == value);
+  }
+}
+
+enum TestosteroneUnit implements Unit<TestosteroneUnit> {
+  ng_dL("ng/dL"),
+  nmol_L("nmol/L");
+
+  @override
+  final String name;
+
+  const TestosteroneUnit(this.name);
+
+  factory TestosteroneUnit.parse(String value) {
+    return TestosteroneUnit.values.firstWhere((unit) => unit.name == value);
+  }
+
+  @override
+  num convert(num value, TestosteroneUnit into) {
+    if (into == this) return value;
+    return switch (into) {
+      TestosteroneUnit.ng_dL => value * 28.84,
+      TestosteroneUnit.nmol_L => value / 28.84
+    };
+  }
+
+  @override
+  String toString() {
+    return name;
+  }
+}
+
+enum Units {
+  pg_mL_ng_dL(
+      estradiol: EstradiolUnit.pg_mL, testosterone: TestosteroneUnit.ng_dL),
+  pmol_L_nmol_L(
+      estradiol: EstradiolUnit.pmol_L, testosterone: TestosteroneUnit.nmol_L);
+
+  final EstradiolUnit estradiol;
+  final TestosteroneUnit testosterone;
+
+  const Units({required this.estradiol, required this.testosterone});
+
+  String get name {
+    return "${estradiol.name} & ${testosterone.name}";
+  }
+
+  @override
+  String toString() {
+    return name;
+  }
+}
+
+class UnitValue<U extends Unit> {
+  final Decimal value;
+  final U unit;
+
+  UnitValue(this.value, this.unit);
+
+  double inUnit(U unit) {
+    return this.unit.convert(value.toDouble(), unit).toDouble();
+  }
+
+  @override
+  String toString() {
+    return "$value $unit";
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UnitValue &&
+          runtimeType == other.runtimeType &&
+          value == other.value &&
+          unit == other.unit;
+
+  @override
+  int get hashCode => Object.hash(value, unit);
+}

--- a/lib/data/model/units.dart
+++ b/lib/data/model/units.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: constant_identifier_names
 import 'package:decimal/decimal.dart';
 
 abstract interface class Unit<T> implements Enum {
@@ -10,7 +9,9 @@ abstract interface class Unit<T> implements Enum {
 }
 
 enum EstradiolUnit implements Unit<EstradiolUnit> {
+  // ignore: constant_identifier_names
   pg_mL("pg/mL"),
+  // ignore: constant_identifier_names
   pmol_L("pmol/L");
 
   @override
@@ -33,12 +34,18 @@ enum EstradiolUnit implements Unit<EstradiolUnit> {
   }
 
   factory EstradiolUnit.parse(String value) {
-    return EstradiolUnit.values.firstWhere((unit) => unit.name == value);
+    try {
+      return EstradiolUnit.values.firstWhere((unit) => unit.name == value);
+    } on StateError {
+      throw ArgumentError("failed to parse $value");
+    }
   }
 }
 
 enum TestosteroneUnit implements Unit<TestosteroneUnit> {
+  // ignore: constant_identifier_names
   ng_dL("ng/dL"),
+  // ignore: constant_identifier_names
   nmol_L("nmol/L");
 
   @override
@@ -47,7 +54,11 @@ enum TestosteroneUnit implements Unit<TestosteroneUnit> {
   const TestosteroneUnit(this.name);
 
   factory TestosteroneUnit.parse(String value) {
-    return TestosteroneUnit.values.firstWhere((unit) => unit.name == value);
+    try {
+      return TestosteroneUnit.values.firstWhere((unit) => unit.name == value);
+    } on StateError {
+      throw ArgumentError("failed to parse $value");
+    }
   }
 
   @override
@@ -66,8 +77,10 @@ enum TestosteroneUnit implements Unit<TestosteroneUnit> {
 }
 
 enum Units {
+  // ignore: constant_identifier_names
   pg_mL_ng_dL(
       estradiol: EstradiolUnit.pg_mL, testosterone: TestosteroneUnit.ng_dL),
+  // ignore: constant_identifier_names
   pmol_L_nmol_L(
       estradiol: EstradiolUnit.pmol_L, testosterone: TestosteroneUnit.nmol_L);
 

--- a/lib/data/model/units.dart
+++ b/lib/data/model/units.dart
@@ -5,7 +5,7 @@ abstract interface class Unit<T> implements Enum {
 
   Unit(this.name);
 
-  num convert(num value, T into);
+  Decimal convert(Decimal value, T into);
 }
 
 enum EstradiolUnit implements Unit<EstradiolUnit> {
@@ -19,12 +19,15 @@ enum EstradiolUnit implements Unit<EstradiolUnit> {
 
   const EstradiolUnit(this.name);
 
+  static Decimal _factor = Decimal.parse('3.671');
+
   @override
-  num convert(num value, EstradiolUnit into) {
+  Decimal convert(Decimal value, EstradiolUnit into) {
     if (into == this) return value;
     return switch (into) {
-      EstradiolUnit.pg_mL => value / 3.671,
-      EstradiolUnit.pmol_L => value * 3.671
+      EstradiolUnit.pg_mL =>
+        (value / _factor).toDecimal(scaleOnInfinitePrecision: 2),
+      EstradiolUnit.pmol_L => value * _factor
     };
   }
 
@@ -61,12 +64,15 @@ enum TestosteroneUnit implements Unit<TestosteroneUnit> {
     }
   }
 
+  static Decimal _factor = Decimal.parse('28.84');
+
   @override
-  num convert(num value, TestosteroneUnit into) {
+  Decimal convert(Decimal value, TestosteroneUnit into) {
     if (into == this) return value;
     return switch (into) {
-      TestosteroneUnit.ng_dL => value * 28.84,
-      TestosteroneUnit.nmol_L => value / 28.84
+      TestosteroneUnit.ng_dL => value * _factor,
+      TestosteroneUnit.nmol_L =>
+        (value / _factor).toDecimal(scaleOnInfinitePrecision: 2)
     };
   }
 
@@ -105,8 +111,8 @@ class UnitValue<U extends Unit> {
 
   UnitValue(this.value, this.unit);
 
-  double inUnit(U unit) {
-    return this.unit.convert(value.toDouble(), unit).toDouble();
+  Decimal inUnit(U unit) {
+    return this.unit.convert(value, unit);
   }
 
   @override

--- a/lib/data/providers/blood_test_provider.dart
+++ b/lib/data/providers/blood_test_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:mona/data/model/blood_test.dart';
 import 'package:mona/data/model/date.dart';
+import 'package:mona/data/model/units.dart';
 import 'package:mona/services/repository.dart';
 
 class BloodTestProvider extends ChangeNotifier {
@@ -37,7 +38,7 @@ class BloodTestProvider extends ChangeNotifier {
     await _fetchBloodTests();
   }
 
-  Map<int, double> getDaysAndBloodTests(Date startDate) {
+  Map<int, double> getDaysAndBloodTests(Date startDate, EstradiolUnit unit) {
     if (bloodtestsSortedDesc.isEmpty) return {};
 
     return Map.fromEntries(
@@ -47,7 +48,7 @@ class BloodTestProvider extends ChangeNotifier {
           .map(
             (bloodtest) => MapEntry(
               bloodtest.localDate.differenceInDays(startDate),
-              bloodtest.estradiolLevels!.toDouble(),
+              bloodtest.estradiolLevels!.inUnit(unit),
             ),
           ),
     );

--- a/lib/data/providers/blood_test_provider.dart
+++ b/lib/data/providers/blood_test_provider.dart
@@ -48,7 +48,7 @@ class BloodTestProvider extends ChangeNotifier {
           .map(
             (bloodtest) => MapEntry(
               bloodtest.localDate.differenceInDays(startDate),
-              bloodtest.estradiolLevels!.inUnit(unit),
+              bloodtest.estradiolLevels!.inUnit(unit).toDouble(),
             ),
           ),
     );

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -84,6 +84,7 @@
     "dataManagement": "Datenverwaltung",
     "exportDataTitle": "Daten exportieren",
     "exportDataSubtitle": "Daten in einer JSON-Datei speichern",
+    "units": "Einheiten",
 
     "updateNoCompatibleApk": "Keine kompatible Aktualisierung für dein Gerät gefunden.",
     "updateAppUpToDate": "Deine App ist auf dem neuesten Stand!",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -232,5 +232,6 @@
   "requiredField": "Required field",
   "mustBePositiveNumber": "Must be a positive number",
   "invalidTotalAmount": "Invalid total amount",
-  "cannotExceedTotalCapacity": "Cannot exceed total capacity"
+  "cannotExceedTotalCapacity": "Cannot exceed total capacity",
+  "units": "Units"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -84,6 +84,7 @@
   "dataManagement": "Data Management",
   "exportDataTitle": "Export Data",
   "exportDataSubtitle": "Save your data to a JSON file",
+  "units": "Units",
 
   "updateNoCompatibleApk": "No compatible update found for your device.",
   "updateAppUpToDate": "Your app is up to date!",
@@ -232,6 +233,5 @@
   "requiredField": "Required field",
   "mustBePositiveNumber": "Must be a positive number",
   "invalidTotalAmount": "Invalid total amount",
-  "cannotExceedTotalCapacity": "Cannot exceed total capacity",
-  "units": "Units"
+  "cannotExceedTotalCapacity": "Cannot exceed total capacity"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -84,6 +84,7 @@
     "dataManagement": "Gestión de datos",
     "exportDataTitle": "Exportar datos",
     "exportDataSubtitle": "Guarda tus datos en un archivo JSON",
+    "units": "Unidades",
 
     "updateNoCompatibleApk": "No se encontró ninguna actualización compatible con tu dispositivo.",
     "updateAppUpToDate": "¡Tu aplicación está actualizada!",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -84,6 +84,7 @@
   "dataManagement": "Gestion des données",
   "exportDataTitle": "Exporter les données",
   "exportDataSubtitle": "Enregistrer vos données dans un fichier JSON",
+  "units": "Unités",
 
   "updateNoCompatibleApk": "Aucune mise à jour compatible avec votre appareil.",
   "updateAppUpToDate": "Votre application est à jour !",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1332,6 +1332,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Cannot exceed total capacity'**
   String get cannotExceedTotalCapacity;
+
+  /// No description provided for @units.
+  ///
+  /// In en, this message translates to:
+  /// **'Units'**
+  String get units;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -535,6 +535,12 @@ abstract class AppLocalizations {
   /// **'Save your data to a JSON file'**
   String get exportDataSubtitle;
 
+  /// No description provided for @units.
+  ///
+  /// In en, this message translates to:
+  /// **'Units'**
+  String get units;
+
   /// No description provided for @updateNoCompatibleApk.
   ///
   /// In en, this message translates to:
@@ -1332,12 +1338,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Cannot exceed total capacity'**
   String get cannotExceedTotalCapacity;
-
-  /// No description provided for @units.
-  ///
-  /// In en, this message translates to:
-  /// **'Units'**
-  String get units;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -757,4 +757,7 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get cannotExceedTotalCapacity =>
       'Darf die Gesamtkapazität nicht überschreiten';
+
+  @override
+  String get units => 'Units';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -267,6 +267,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get exportDataSubtitle => 'Daten in einer JSON-Datei speichern';
 
   @override
+  String get units => 'Einheiten';
+
+  @override
   String get updateNoCompatibleApk =>
       'Keine kompatible Aktualisierung für dein Gerät gefunden.';
 
@@ -757,7 +760,4 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get cannotExceedTotalCapacity =>
       'Darf die Gesamtkapazität nicht überschreiten';
-
-  @override
-  String get units => 'Units';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -747,4 +747,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get cannotExceedTotalCapacity => 'Cannot exceed total capacity';
+
+  @override
+  String get units => 'Units';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -262,6 +262,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get exportDataSubtitle => 'Save your data to a JSON file';
 
   @override
+  String get units => 'Units';
+
+  @override
   String get updateNoCompatibleApk =>
       'No compatible update found for your device.';
 
@@ -747,7 +750,4 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get cannotExceedTotalCapacity => 'Cannot exceed total capacity';
-
-  @override
-  String get units => 'Units';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -753,4 +753,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get cannotExceedTotalCapacity => 'No puede superar la capacidad total';
+
+  @override
+  String get units => 'Units';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -265,6 +265,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get exportDataSubtitle => 'Guarda tus datos en un archivo JSON';
 
   @override
+  String get units => 'Unidades';
+
+  @override
   String get updateNoCompatibleApk =>
       'No se encontró ninguna actualización compatible con tu dispositivo.';
 
@@ -753,7 +756,4 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get cannotExceedTotalCapacity => 'No puede superar la capacidad total';
-
-  @override
-  String get units => 'Units';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -755,4 +755,7 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get cannotExceedTotalCapacity =>
       'Ne peut pas dépasser la capacité totale';
+
+  @override
+  String get units => 'Units';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -267,6 +267,9 @@ class AppLocalizationsFr extends AppLocalizations {
       'Enregistrer vos données dans un fichier JSON';
 
   @override
+  String get units => 'Unités';
+
+  @override
   String get updateNoCompatibleApk =>
       'Aucune mise à jour compatible avec votre appareil.';
 
@@ -755,7 +758,4 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get cannotExceedTotalCapacity =>
       'Ne peut pas dépasser la capacité totale';
-
-  @override
-  String get units => 'Units';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -750,6 +750,9 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get cannotExceedTotalCapacity => 'Não pode exceder a capacidade total';
+
+  @override
+  String get units => 'Units';
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -264,6 +264,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get exportDataSubtitle => 'Salve seus dados num ficheiro JSON';
 
   @override
+  String get units => 'Unidades';
+
+  @override
   String get updateNoCompatibleApk =>
       'Não foi encontrada nenhuma atualização compatível com o seu dispositivo.';
 
@@ -750,9 +753,6 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get cannotExceedTotalCapacity => 'Não pode exceder a capacidade total';
-
-  @override
-  String get units => 'Units';
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).
@@ -1013,6 +1013,9 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String get exportDataSubtitle => 'Salve seus dados em um arquivo JSON';
+
+  @override
+  String get units => 'Unidades';
 
   @override
   String get updateNoCompatibleApk =>

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -780,4 +780,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get cannotExceedTotalCapacity => 'Nemôže presahovať celkové množstvo';
+
+  @override
+  String get units => 'Units';
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -276,6 +276,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get exportDataSubtitle => 'Ulož svoje dáta do JSON súboru';
 
   @override
+  String get units => 'Jednotky';
+
+  @override
   String get updateNoCompatibleApk =>
       'Pre tvoje zariadenie nebola nájdená kompatibilná aktualizácia.';
 
@@ -780,7 +783,4 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get cannotExceedTotalCapacity => 'Nemôže presahovať celkové množstvo';
-
-  @override
-  String get units => 'Units';
 }

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -750,4 +750,7 @@ class AppLocalizationsUk extends AppLocalizations {
   @override
   String get cannotExceedTotalCapacity =>
       'Не може перевищувати загальну ємність';
+
+  @override
+  String get units => 'Units';
 }

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -265,6 +265,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get exportDataSubtitle => 'Зберегти дані в JSON файл';
 
   @override
+  String get units => 'Одиниці виміру';
+
+  @override
   String get updateNoCompatibleApk =>
       'Сумісних оновлень для вашого пристрою не знайдено.';
 
@@ -750,7 +753,4 @@ class AppLocalizationsUk extends AppLocalizations {
   @override
   String get cannotExceedTotalCapacity =>
       'Не може перевищувати загальну ємність';
-
-  @override
-  String get units => 'Units';
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -84,6 +84,7 @@
     "dataManagement": "Gestão de dados",
     "exportDataTitle": "Exportar dados",
     "exportDataSubtitle": "Salve seus dados num ficheiro JSON",
+    "units": "Unidades",
 
     "updateNoCompatibleApk": "Não foi encontrada nenhuma atualização compatível com o seu dispositivo.",
     "updateAppUpToDate": "A sua aplicação está atualizada!",

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -84,6 +84,7 @@
     "dataManagement": "Gerenciamento de dados",
     "exportDataTitle": "Exportar dados",
     "exportDataSubtitle": "Salve seus dados em um arquivo JSON",
+    "units": "Unidades",
 
     "updateNoCompatibleApk": "Nenhuma atualização compatível com seu dispositivo foi encontrada.",
     "updateAppUpToDate": "Seu app está atualizado!",

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -84,6 +84,7 @@
   "dataManagement": "Správa dát",
   "exportDataTitle": "Export dát",
   "exportDataSubtitle": "Ulož svoje dáta do JSON súboru",
+  "units": "Jednotky",
 
   "updateNoCompatibleApk": "Pre tvoje zariadenie nebola nájdená kompatibilná aktualizácia.",
   "updateAppUpToDate": "Tvoja apka má najnovšiu aktualizáciu!",

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -84,6 +84,7 @@
   "dataManagement": "Керування даними",
   "exportDataTitle": "Експортувати дані",
   "exportDataSubtitle": "Зберегти дані в JSON файл",
+  "units": "Одиниці виміру",
 
   "updateNoCompatibleApk": "Сумісних оновлень для вашого пристрою не знайдено.",
   "updateAppUpToDate": "Ваш застосунок останньої версії!",

--- a/lib/services/db/db_tables.dart
+++ b/lib/services/db/db_tables.dart
@@ -51,6 +51,8 @@ const String createBloodTestsTable = '''
       dateTime TEXT NOT NULL,
       timeZone TEXT NOT NULL,
       estradiolLevels TEXT,
-      testosteroneLevels TEXT
+      testosteroneLevels TEXT,
+      estradiolUnit TEXT,
+      testosteroneUnit TEXT
     )
     ''';

--- a/lib/services/db/upgrade/v7.dart
+++ b/lib/services/db/upgrade/v7.dart
@@ -5,9 +5,20 @@ class DbUpgradeV7 implements DbUpgrade {
   @override
   Future<void> upgrade(Database db, int oldVersion, int newVersion) async {
     await _addnotes(db);
+    await _upgradeBloodTest(db);
   }
 
   Future<void> _addnotes(Database db) async {
     await db.execute('ALTER TABLE medication_intakes ADD COLUMN notes TEXT');
+  }
+
+  Future<void> _upgradeBloodTest(Database db) async {
+    // add blood test units
+    await db.execute('ALTER TABLE blood_tests ADD COLUMN estradiolUnit TEXT');
+    await db
+        .execute('ALTER TABLE blood_tests ADD COLUMN testosteroneUnit TEXT');
+    // assume existing entries use pg/mL & ng/dL
+    await db.execute(
+        "UPDATE blood_tests SET estradiolUnit = 'pg/mL', testosteroneUnit = 'ng/dL'");
   }
 }

--- a/lib/services/preferences_service.dart
+++ b/lib/services/preferences_service.dart
@@ -2,12 +2,14 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:mona/data/model/molecule.dart';
+import 'package:mona/data/model/units.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class PreferencesService extends ChangeNotifier {
   static const _notificationsEnabledKey = 'notifications_enabled';
   static const _customMoleculesKey = 'custom_molecules';
   static const _languageTagKey = 'language_tag';
+  static const _unitsTagKey = "units";
 
   static const bool defaultNotificationsEnabled = false;
 
@@ -46,6 +48,13 @@ class PreferencesService extends ChangeNotifier {
     } else {
       await _prefs.setString(_languageTagKey, code);
     }
+    notifyListeners();
+  }
+
+  Units get units => Units.values[_prefs.getInt(_unitsTagKey) ?? 0];
+
+  Future<void> setUnits(Units units) async {
+    await _prefs.setInt(_unitsTagKey, units.index);
     notifyListeners();
   }
 

--- a/lib/ui/views/chart/blood_test_page.dart
+++ b/lib/ui/views/chart/blood_test_page.dart
@@ -56,9 +56,9 @@ class BloodTestPage extends StatelessWidget {
       subtitle: Text(
         [
           if (bloodtest.estradiolLevels != null)
-            '${l10n.estradiol} : ${bloodtest.estradiolLevels} pg/mL',
+            '${l10n.estradiol} : ${bloodtest.estradiolLevels}',
           if (bloodtest.testosteroneLevels != null)
-            '${l10n.testosterone} : ${bloodtest.testosteroneLevels} ng/dL',
+            '${l10n.testosterone} : ${bloodtest.testosteroneLevels}',
         ].join('\n'),
       ),
       onTap: () {

--- a/lib/ui/views/chart/chart_graph.dart
+++ b/lib/ui/views/chart/chart_graph.dart
@@ -4,10 +4,12 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:mona/data/model/date.dart';
 import 'package:mona/data/model/graph_calculator.dart';
+import 'package:mona/data/model/units.dart';
 import 'package:mona/data/providers/blood_test_provider.dart';
 import 'package:mona/data/providers/medication_intake_provider.dart';
 import 'package:mona/l10n/app_localizations.dart';
 import 'package:mona/l10n/build_context_extensions.dart';
+import 'package:mona/services/preferences_service.dart';
 import 'package:provider/provider.dart';
 
 class _ChartConstants {
@@ -30,21 +32,23 @@ class MainGraph extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final medicationIntakeProvider = context.watch<MedicationIntakeProvider>();
+    final preferencesProvider = context.watch<PreferencesService>();
     final bloodTestProvider = context.watch<BloodTestProvider>();
     final theme = Theme.of(context);
     final l10n = context.l10n;
     final Date firstDay = medicationIntakeProvider.getFirstIntakeLocalDate()!;
+    final unit = preferencesProvider.units.estradiol;
 
     Map<int, GraphIntake> daysAndIntakes =
         medicationIntakeProvider.getDaysAndIntakes();
 
     Map<int, double> daysAndBloodTests =
-        bloodTestProvider.getDaysAndBloodTests(firstDay);
+        bloodTestProvider.getDaysAndBloodTests(firstDay, unit);
 
     if (daysAndIntakes.isEmpty) return SizedBox.shrink();
 
     final List<FlSpot> spots =
-        GraphCalculator().generateFlSpots(daysAndIntakes);
+        GraphCalculator().generateFlSpots(daysAndIntakes, unit);
 
     final List<FlSpot> bloodSpots = daysAndBloodTests.entries
         .map((e) => FlSpot(e.key.toDouble(), e.value))
@@ -59,7 +63,7 @@ class MainGraph extends StatelessWidget {
     FlSpot? todaySpot;
     if (daysSinceStart <= totalDays + GraphCalculator.tMaxOffset) {
       final todayConcentration = GraphCalculator()
-          .totalConcentrationAtTime(daysSinceStart, daysAndIntakes);
+          .totalConcentrationAtTime(daysSinceStart, daysAndIntakes, unit);
       todaySpot = FlSpot(daysSinceStart, todayConcentration);
     }
 
@@ -79,7 +83,7 @@ class MainGraph extends StatelessWidget {
                   const EdgeInsets.only(right: _ChartConstants.axesPadding),
               child: RotatedBox(
                 quarterTurns: -1,
-                child: Text('${l10n.concentration} (pg/ml)',
+                child: Text('${l10n.concentration} ($unit)',
                     style: const TextStyle(
                         fontSize: _ChartConstants.titleFontSize)),
               ),
@@ -99,9 +103,9 @@ class MainGraph extends StatelessWidget {
                     _buildBloodTestData(bloodSpots, theme),
                   ],
                   lineTouchData:
-                      _buildLineTouchData(context, theme, firstDay, l10n),
+                      _buildLineTouchData(context, theme, firstDay, l10n, unit),
                   extraLinesData: _buildTodayVerticalLine(
-                      theme, todaySpot, daysSinceStart, l10n),
+                      theme, todaySpot, daysSinceStart, l10n, unit),
                 ),
               ),
             ),
@@ -112,11 +116,11 @@ class MainGraph extends StatelessWidget {
   }
 
   ExtraLinesData? _buildTodayVerticalLine(ThemeData theme, FlSpot? todaySpot,
-      double daysSinceStart, AppLocalizations l10n) {
+      double daysSinceStart, AppLocalizations l10n, EstradiolUnit unit) {
     if (todaySpot == null) return null;
 
     final nowLabel =
-        '${l10n.chartNowConcentration(todaySpot.y.toStringAsFixed(0))} pg/ml';
+        '${l10n.chartNowConcentration(todaySpot.y.toStringAsFixed(0))} $unit';
 
     return ExtraLinesData(
       verticalLines: [
@@ -162,7 +166,7 @@ class MainGraph extends StatelessWidget {
   }
 
   LineTouchData _buildLineTouchData(BuildContext context, ThemeData theme,
-      Date firstDay, AppLocalizations l10n) {
+      Date firstDay, AppLocalizations l10n, EstradiolUnit unit) {
     return LineTouchData(
       touchTooltipData: LineTouchTooltipData(
         getTooltipColor: (touchedSpots) => theme.colorScheme.tertiaryContainer,
@@ -177,7 +181,7 @@ class MainGraph extends StatelessWidget {
               text = t.y.toStringAsFixed(1);
             } else {
               text =
-                  '${l10n.chartBloodTestLevelTooltip(_getDateLabel(t.x, firstDay, context), t.y.toStringAsFixed(1))} pg/ml';
+                  '${l10n.chartBloodTestLevelTooltip(_getDateLabel(t.x, firstDay, context), t.y.toStringAsFixed(1))} $unit';
             }
             return LineTooltipItem(
                 text,

--- a/lib/ui/views/chart/edit_blood_test_page.dart
+++ b/lib/ui/views/chart/edit_blood_test_page.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:mona/data/model/blood_test.dart';
+import 'package:mona/data/model/units.dart';
 import 'package:mona/data/providers/blood_test_provider.dart';
 import 'package:mona/l10n/build_context_extensions.dart';
+import 'package:mona/services/preferences_service.dart';
 import 'package:mona/ui/widgets/dialogs.dart';
 import 'package:mona/ui/widgets/forms/form_datetime_field.dart';
 import 'package:mona/ui/widgets/forms/form_spacer.dart';
@@ -24,6 +26,7 @@ class _EditBloodTestPageState extends State<EditBloodTestPage> {
   late TextEditingController _testosteroneLevelsController;
   late DateTime _testDateTime;
   late BloodTestProvider _bloodTestProvider;
+  late PreferencesService _preferencesService;
   bool _dateTimeChanged = false;
 
   String? get _testDateError =>
@@ -56,12 +59,25 @@ class _EditBloodTestPageState extends State<EditBloodTestPage> {
     final timezone =
         _dateTimeChanged ? await FlutterTimezone.getLocalTimezone() : null;
 
+    final defaultUnits = _preferencesService.units;
+
+    final estradiolLevels = _estradiolLevelsController.text.toDecimalOrNull;
+    final estradiolUnit =
+        widget.bloodtest.estradiolLevels?.unit ?? defaultUnits.estradiol;
+    final testosteroneLevels =
+        _testosteroneLevelsController.text.toDecimalOrNull;
+    final testosteroneUnit =
+        widget.bloodtest.testosteroneLevels?.unit ?? defaultUnits.testosterone;
+
     final updatedBloodTest = widget.bloodtest.copyWith(
-      dateTime: _testDateTime.toUtc(),
-      timeZone: timezone?.identifier,
-      estradiolLevels: _estradiolLevelsController.text.toDecimalOrNull,
-      testosteroneLevels: _testosteroneLevelsController.text.toDecimalOrNull,
-    );
+        dateTime: _testDateTime.toUtc(),
+        timeZone: timezone?.identifier,
+        estradiolLevels: estradiolLevels != null
+            ? UnitValue(estradiolLevels, estradiolUnit)
+            : null,
+        testosteroneLevels: testosteroneLevels != null
+            ? UnitValue(testosteroneLevels, testosteroneUnit)
+            : null);
     await _bloodTestProvider.updateBloodTest(updatedBloodTest);
 
     if (!mounted) return;
@@ -72,10 +88,11 @@ class _EditBloodTestPageState extends State<EditBloodTestPage> {
   void initState() {
     super.initState();
     _bloodTestProvider = Provider.of<BloodTestProvider>(context, listen: false);
+    _preferencesService = Provider.of(context, listen: false);
     _estradiolLevelsController = TextEditingController(
-        text: widget.bloodtest.estradiolLevels?.toString());
+        text: widget.bloodtest.estradiolLevels?.value.toString());
     _testosteroneLevelsController = TextEditingController(
-        text: widget.bloodtest.testosteroneLevels?.toString());
+        text: widget.bloodtest.testosteroneLevels?.value.toString());
     _testDateTime = widget.bloodtest.localDateTime;
   }
 
@@ -89,6 +106,7 @@ class _EditBloodTestPageState extends State<EditBloodTestPage> {
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
+    final defaultUnits = _preferencesService.units;
     return ModelForm(
       title: l10n.editBloodTest,
       submitButtonLabel: l10n.save,
@@ -103,7 +121,8 @@ class _EditBloodTestPageState extends State<EditBloodTestPage> {
           onChanged: _refresh,
           inputType: TextInputType.numberWithOptions(decimal: true),
           regexFormatter: '[0-9.,]',
-          suffixText: 'pg/mL',
+          suffixText: widget.bloodtest.estradiolLevels?.unit.name ??
+              defaultUnits.estradiol.name,
         ),
         FormTextField(
           controller: _testosteroneLevelsController,
@@ -112,7 +131,8 @@ class _EditBloodTestPageState extends State<EditBloodTestPage> {
           onChanged: _refresh,
           inputType: TextInputType.numberWithOptions(decimal: true),
           regexFormatter: '[0-9.,]',
-          suffixText: 'ng/dL',
+          suffixText: widget.bloodtest.testosteroneLevels?.unit.name ??
+              defaultUnits.testosterone.name,
         ),
         FormSpacer(),
         FormDateTimeField(

--- a/lib/ui/views/chart/new_blood_test_page.dart
+++ b/lib/ui/views/chart/new_blood_test_page.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:mona/data/model/blood_test.dart';
+import 'package:mona/data/model/units.dart';
 import 'package:mona/data/providers/blood_test_provider.dart';
 import 'package:mona/l10n/build_context_extensions.dart';
+import 'package:mona/services/preferences_service.dart';
 import 'package:mona/ui/widgets/forms/form_datetime_field.dart';
 import 'package:mona/ui/widgets/forms/form_spacer.dart';
 import 'package:mona/ui/widgets/forms/form_text_field.dart';
@@ -19,11 +21,14 @@ class _NewBloodTestPageState extends State<NewBloodTestPage> {
   late TextEditingController _estradiolLevelsController;
   late TextEditingController _testosteroneLevelsController;
   late DateTime _testDateTime;
+  late PreferencesService _preferencesService;
 
   String? get _testDateError =>
       BloodTest.validateDate(context.l10n, _testDateTime);
+
   String? get _estradiolError =>
       BloodTest.validateLevel(context.l10n, _estradiolLevelsController.text);
+
   String? get _testosteroneError =>
       BloodTest.validateLevel(context.l10n, _testosteroneLevelsController.text);
 
@@ -50,12 +55,17 @@ class _NewBloodTestPageState extends State<NewBloodTestPage> {
         _testosteroneLevelsController.text.toDecimalOrNull;
     final timezone = await FlutterTimezone.getLocalTimezone();
     final tzName = timezone.identifier;
+    final units = _preferencesService.units;
 
     final bloodtest = BloodTest(
       dateTime: _testDateTime.toUtc(),
       timeZone: tzName,
-      estradiolLevels: estradiolLevels,
-      testosteroneLevels: testosteroneLevels,
+      estradiolLevels: estradiolLevels != null
+          ? UnitValue(estradiolLevels, units.estradiol)
+          : null,
+      testosteroneLevels: testosteroneLevels != null
+          ? UnitValue(testosteroneLevels, units.testosterone)
+          : null,
     );
     await bloodTestProvider.add(bloodtest);
 
@@ -69,6 +79,7 @@ class _NewBloodTestPageState extends State<NewBloodTestPage> {
     _estradiolLevelsController = TextEditingController();
     _testosteroneLevelsController = TextEditingController();
     _testDateTime = DateTime.now();
+    _preferencesService = Provider.of(context, listen: false);
   }
 
   @override
@@ -81,6 +92,7 @@ class _NewBloodTestPageState extends State<NewBloodTestPage> {
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
+    final units = _preferencesService.units;
     return ModelForm(
       title: l10n.newBloodTest,
       submitButtonLabel: l10n.add,
@@ -94,7 +106,7 @@ class _NewBloodTestPageState extends State<NewBloodTestPage> {
           inputType: TextInputType.numberWithOptions(decimal: true),
           regexFormatter: '[0-9.,]',
           errorText: _estradiolError,
-          suffixText: 'pg/mL',
+          suffixText: units.estradiol.name,
         ),
         FormTextField(
           controller: _testosteroneLevelsController,
@@ -103,7 +115,7 @@ class _NewBloodTestPageState extends State<NewBloodTestPage> {
           inputType: TextInputType.numberWithOptions(decimal: true),
           regexFormatter: '[0-9.,]',
           errorText: _testosteroneError,
-          suffixText: 'ng/dL',
+          suffixText: units.testosterone.name,
         ),
         FormSpacer(),
         FormDateTimeField(

--- a/lib/ui/views/home/settings/settings_page.dart
+++ b/lib/ui/views/home/settings/settings_page.dart
@@ -12,6 +12,7 @@ import 'package:mona/services/update_service.dart';
 import 'package:mona/ui/constants/dimensions.dart';
 import 'package:mona/ui/views/home/settings/language_page.dart';
 import 'package:mona/ui/views/home/settings/schedules/schedules_page.dart';
+import 'package:mona/ui/views/home/settings/units_page.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
@@ -260,6 +261,15 @@ class _SettingsPageState extends State<SettingsPage>
               Navigator.of(context).push(
                 MaterialPageRoute<void>(builder: (context) => LanguagePage()),
               );
+            },
+          ),
+          ListTile(
+            title: Text(localizations.units),
+            subtitle: Text(preferencesService.units.name),
+            trailing: Icon(Icons.chevron_right),
+            onTap: () {
+              Navigator.of(context).push(
+                  MaterialPageRoute<void>(builder: (context) => UnitsPage()));
             },
           ),
           if (Platform.isAndroid && !isPlayStoreDistribution) ...[

--- a/lib/ui/views/home/settings/units_page.dart
+++ b/lib/ui/views/home/settings/units_page.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:mona/data/model/units.dart';
+import 'package:mona/l10n/build_context_extensions.dart';
+import 'package:mona/services/preferences_service.dart';
+import 'package:provider/provider.dart';
+
+class UnitsPage extends StatelessWidget {
+  const UnitsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final preferencesService = context.watch<PreferencesService>();
+    final savedUnits = preferencesService.units;
+
+    void onUnitsChanged(Units? value) {
+      preferencesService.setUnits(value ?? Units.pg_mL_ng_dL);
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: Text(context.l10n.units)),
+      body: RadioGroup<Units>(
+        groupValue: savedUnits,
+        onChanged: onUnitsChanged,
+        child: ListView(
+          children: [
+            for (final units in Units.values)
+              RadioListTile<Units>(
+                title: Text(units.name),
+                value: units,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/data/model/blood_test_test.dart
+++ b/test/data/model/blood_test_test.dart
@@ -1,6 +1,7 @@
 import 'package:decimal/decimal.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mona/data/model/blood_test.dart';
+import 'package:mona/data/model/units.dart';
 
 void main() {
   group('BloodTest', () {
@@ -10,7 +11,7 @@ void main() {
         id: 1,
         dateTime: DateTime.utc(2025, 3, 14, 6, 7),
         timeZone: 'Etc/UTC',
-        estradiolLevels: Decimal.parse('167.1'),
+        estradiolLevels: UnitValue(Decimal.parse('167.1'), EstradiolUnit.pg_mL),
         testosteroneLevels: null,
       );
 
@@ -38,8 +39,9 @@ void main() {
         id: 1,
         dateTime: DateTime.utc(2024, 1, 1),
         timeZone: 'Etc/UTC',
-        estradiolLevels: Decimal.parse('167.1'),
-        testosteroneLevels: Decimal.parse('1.67'),
+        estradiolLevels: UnitValue(Decimal.parse('167.1'), EstradiolUnit.pg_mL),
+        testosteroneLevels:
+            UnitValue(Decimal.parse('1.67'), TestosteroneUnit.ng_dL),
       );
       final newDate = DateTime.utc(2025, 1, 1);
 
@@ -65,8 +67,9 @@ void main() {
         id: 1,
         dateTime: DateTime.utc(2024, 1, 1),
         timeZone: 'Etc/UTC',
-        estradiolLevels: Decimal.parse('10'),
-        testosteroneLevels: Decimal.parse('20'),
+        estradiolLevels: UnitValue(Decimal.parse('10'), EstradiolUnit.pg_mL),
+        testosteroneLevels:
+            UnitValue(Decimal.parse('20'), TestosteroneUnit.ng_dL),
       );
 
       // Act

--- a/test/data/model/units_test.dart
+++ b/test/data/model/units_test.dart
@@ -1,0 +1,49 @@
+import 'package:decimal/decimal.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mona/data/model/units.dart';
+
+void main() {
+  group('UnitValue', () {
+    test('estradiol converts same does not change value', () {
+      final value = UnitValue(200.toDecimal(), EstradiolUnit.pg_mL);
+      final converted = value.inUnit(EstradiolUnit.pg_mL);
+
+      expect(converted, 200.0);
+    });
+
+    test('estradiol converts from pg/mL to pmol/L', () {
+      final value = UnitValue(200.toDecimal(), EstradiolUnit.pg_mL);
+      final converted = value.inUnit(EstradiolUnit.pmol_L);
+
+      expect(converted, moreOrLessEquals(734.20, epsilon: 0.01));
+    });
+
+    test('estradiol converts from pmol/L to pg/mL', () {
+      final value = UnitValue(700.toDecimal(), EstradiolUnit.pmol_L);
+      final converted = value.inUnit(EstradiolUnit.pg_mL);
+
+      expect(converted, moreOrLessEquals(190.68, epsilon: 0.01));
+    });
+
+    test('testosterone converts same does not change value', () {
+      final value = UnitValue(250.toDecimal(), TestosteroneUnit.ng_dL);
+      final converted = value.inUnit(TestosteroneUnit.ng_dL);
+
+      expect(converted, 250.0);
+    });
+
+    test('testosterone converts from ng/dL to nmol/L', () {
+      final value = UnitValue(250.toDecimal(), TestosteroneUnit.ng_dL);
+      final converted = value.inUnit(TestosteroneUnit.nmol_L);
+
+      expect(converted, moreOrLessEquals(8.67, epsilon: 0.01));
+    });
+
+    test('testosterone converts from nmol/L to ng/dL', () {
+      final value = UnitValue(8.toDecimal(), TestosteroneUnit.nmol_L);
+      final converted = value.inUnit(TestosteroneUnit.ng_dL);
+
+      expect(converted, moreOrLessEquals(230.72, epsilon: 0.01));
+    });
+  });
+}

--- a/test/data/model/units_test.dart
+++ b/test/data/model/units_test.dart
@@ -8,42 +8,42 @@ void main() {
       final value = UnitValue(200.toDecimal(), EstradiolUnit.pg_mL);
       final converted = value.inUnit(EstradiolUnit.pg_mL);
 
-      expect(converted, 200.0);
+      expect(converted, 200.toDecimal());
     });
 
     test('estradiol converts from pg/mL to pmol/L', () {
       final value = UnitValue(200.toDecimal(), EstradiolUnit.pg_mL);
       final converted = value.inUnit(EstradiolUnit.pmol_L);
 
-      expect(converted, moreOrLessEquals(734.20, epsilon: 0.01));
+      expect(converted, Decimal.parse('734.20'));
     });
 
     test('estradiol converts from pmol/L to pg/mL', () {
       final value = UnitValue(700.toDecimal(), EstradiolUnit.pmol_L);
       final converted = value.inUnit(EstradiolUnit.pg_mL);
 
-      expect(converted, moreOrLessEquals(190.68, epsilon: 0.01));
+      expect(converted, Decimal.parse('190.68'));
     });
 
     test('testosterone converts same does not change value', () {
       final value = UnitValue(250.toDecimal(), TestosteroneUnit.ng_dL);
       final converted = value.inUnit(TestosteroneUnit.ng_dL);
 
-      expect(converted, 250.0);
+      expect(converted, 250.toDecimal());
     });
 
     test('testosterone converts from ng/dL to nmol/L', () {
       final value = UnitValue(250.toDecimal(), TestosteroneUnit.ng_dL);
       final converted = value.inUnit(TestosteroneUnit.nmol_L);
 
-      expect(converted, moreOrLessEquals(8.67, epsilon: 0.01));
+      expect(converted, Decimal.parse('8.66'));
     });
 
     test('testosterone converts from nmol/L to ng/dL', () {
       final value = UnitValue(8.toDecimal(), TestosteroneUnit.nmol_L);
       final converted = value.inUnit(TestosteroneUnit.ng_dL);
 
-      expect(converted, moreOrLessEquals(230.72, epsilon: 0.01));
+      expect(converted, Decimal.parse('230.72'));
     });
   });
 }

--- a/test/data/providers/blood_test_provider_test.dart
+++ b/test/data/providers/blood_test_provider_test.dart
@@ -2,6 +2,7 @@ import 'package:decimal/decimal.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mona/data/model/blood_test.dart';
 import 'package:mona/data/model/date.dart';
+import 'package:mona/data/model/units.dart';
 import 'package:mona/data/providers/blood_test_provider.dart';
 import 'package:timezone/data/latest_all.dart' as tz;
 import 'generic_repository_mock.dart';
@@ -33,8 +34,9 @@ void main() {
         id: 1,
         dateTime: DateTime.utc(2025, 3, 14, 6, 7),
         timeZone: 'Etc/UTC',
-        estradiolLevels: Decimal.parse('167.1'),
-        testosteroneLevels: Decimal.parse('1.67'),
+        estradiolLevels: UnitValue(Decimal.parse('167.1'), EstradiolUnit.pg_mL),
+        testosteroneLevels:
+            UnitValue(Decimal.parse('1.67'), TestosteroneUnit.ng_dL),
       ));
 
       // Act
@@ -54,8 +56,10 @@ void main() {
     test('add inserts a new test', () async {
       // Arrange
       final newDate = DateTime.utc(2025, 1, 1, 1, 1);
-      final newEstradiolLevels = Decimal.parse('111.1');
-      final newTestosteroneLevels = Decimal.parse('1.1');
+      final newEstradiolLevels =
+          UnitValue(Decimal.parse('111.1'), EstradiolUnit.pg_mL);
+      final newTestosteroneLevels =
+          UnitValue(Decimal.parse('1.1'), TestosteroneUnit.ng_dL);
       provider = BloodTestProvider(repository: repo);
 
       // Act
@@ -82,8 +86,9 @@ void main() {
         id: 1,
         dateTime: DateTime.utc(2025, 3, 14, 6, 7),
         timeZone: 'Etc/UTC',
-        estradiolLevels: Decimal.parse('167.1'),
-        testosteroneLevels: Decimal.parse('1.67'),
+        estradiolLevels: UnitValue(Decimal.parse('167.1'), EstradiolUnit.pg_mL),
+        testosteroneLevels:
+            UnitValue(Decimal.parse('1.67'), TestosteroneUnit.ng_dL),
       ));
       provider = BloodTestProvider(repository: repo);
       final bloodtestToUpdate = repo.items.first;
@@ -110,8 +115,9 @@ void main() {
         id: 1,
         dateTime: DateTime.utc(2025, 3, 14, 6, 7),
         timeZone: 'Etc/UTC',
-        estradiolLevels: Decimal.parse('167.1'),
-        testosteroneLevels: Decimal.parse('1.67'),
+        estradiolLevels: UnitValue(Decimal.parse('167.1'), EstradiolUnit.pg_mL),
+        testosteroneLevels:
+            UnitValue(Decimal.parse('1.67'), TestosteroneUnit.ng_dL),
       ));
       provider = BloodTestProvider(repository: repo);
 
@@ -128,8 +134,9 @@ void main() {
         id: 1,
         dateTime: DateTime.utc(2025, 3, 14, 6, 7),
         timeZone: 'Etc/UTC',
-        estradiolLevels: Decimal.parse('167.1'),
-        testosteroneLevels: Decimal.parse('1.67'),
+        estradiolLevels: UnitValue(Decimal.parse('167.1'), EstradiolUnit.pg_mL),
+        testosteroneLevels:
+            UnitValue(Decimal.parse('1.67'), TestosteroneUnit.ng_dL),
       );
 
       repo.insert(bloodtestToDelete);
@@ -148,22 +155,25 @@ void main() {
         id: 666,
         dateTime: DateTime.utc(2025, 5, 4, 3, 0),
         timeZone: 'Etc/UTC',
-        estradiolLevels: Decimal.parse('234.5'),
-        testosteroneLevels: Decimal.parse('2.34'),
+        estradiolLevels: UnitValue(Decimal.parse('234.5'), EstradiolUnit.pg_mL),
+        testosteroneLevels:
+            UnitValue(Decimal.parse('2.34'), TestosteroneUnit.ng_dL),
       ));
       provider.add(BloodTest(
         id: 667, // ekip
         dateTime: DateTime.utc(2025, 6, 7, 8, 9),
         timeZone: 'Etc/UTC',
-        estradiolLevels: Decimal.parse('292.9'),
-        testosteroneLevels: Decimal.parse('2.43'),
+        estradiolLevels: UnitValue(Decimal.parse('292.9'), EstradiolUnit.pg_mL),
+        testosteroneLevels:
+            UnitValue(Decimal.parse('2.43'), TestosteroneUnit.ng_dL),
       ));
       provider.add(BloodTest(
         id: 668,
         dateTime: DateTime.utc(2025, 3, 2, 1, 0),
         timeZone: 'Etc/UTC',
-        estradiolLevels: Decimal.parse('261.2'),
-        testosteroneLevels: Decimal.parse('3.3'),
+        estradiolLevels: UnitValue(Decimal.parse('261.2'), EstradiolUnit.pg_mL),
+        testosteroneLevels:
+            UnitValue(Decimal.parse('3.3'), TestosteroneUnit.ng_dL),
       ));
 
       final sorted = provider.bloodtestsSortedDesc;
@@ -190,8 +200,8 @@ void main() {
         provider = BloodTestProvider(repository: repo);
 
         // Act
-        final result = provider
-            .getDaysAndBloodTests(Date.fromDateTime(DateTime(2025, 5, 4)));
+        final result = provider.getDaysAndBloodTests(
+            Date.fromDateTime(DateTime(2025, 5, 4)), EstradiolUnit.pg_mL);
 
         // Assert
         expect(result, {});
@@ -204,20 +214,23 @@ void main() {
           id: 666,
           dateTime: DateTime.utc(2025, 5, 4, 3, 0),
           timeZone: 'Etc/UTC',
-          estradiolLevels: Decimal.parse('234.5'),
-          testosteroneLevels: Decimal.parse('2.34'),
+          estradiolLevels:
+              UnitValue(Decimal.parse('234.5'), EstradiolUnit.pg_mL),
+          testosteroneLevels:
+              UnitValue(Decimal.parse('2.34'), TestosteroneUnit.ng_dL),
         ));
         await provider.add(BloodTest(
           id: 667,
           dateTime: DateTime.utc(2025, 5, 5),
           timeZone: 'Etc/UTC',
           estradiolLevels: null,
-          testosteroneLevels: Decimal.parse('5.0'),
+          testosteroneLevels:
+              UnitValue(Decimal.parse('5.0'), TestosteroneUnit.ng_dL),
         ));
 
         // Act
-        final result = provider
-            .getDaysAndBloodTests(Date.fromDateTime(DateTime(2025, 5, 4)));
+        final result = provider.getDaysAndBloodTests(
+            Date.fromDateTime(DateTime(2025, 5, 4)), EstradiolUnit.pg_mL);
 
         // Assert
         expect(result, {0: 234.5});
@@ -230,13 +243,15 @@ void main() {
           id: 668,
           dateTime: DateTime.utc(2025, 5, 6, 23, 59),
           timeZone: 'Etc/UTC',
-          estradiolLevels: Decimal.parse('12.3'),
+          estradiolLevels:
+              UnitValue(Decimal.parse('12.3'), EstradiolUnit.pg_mL),
           testosteroneLevels: null,
         ));
 
         // Act
         final result = provider.getDaysAndBloodTests(
-            Date.fromDateTime(DateTime(2025, 5, 4, 21, 0)));
+            Date.fromDateTime(DateTime(2025, 5, 4, 21, 0)),
+            EstradiolUnit.pg_mL);
 
         // Assert
         expect(result, {2: 12.3});

--- a/test/services/app_database_test.dart
+++ b/test/services/app_database_test.dart
@@ -192,5 +192,31 @@ void main() {
         ],
       );
     });
+
+    test('can insert and query blood_tests', () async {
+      final id = await db.insert('blood_tests', {
+        'dateTime': DateTime(2025, 9, 13).toIso8601String(),
+        'timeZone': 'Etc/UTC',
+        'estradiolLevels': '167.1',
+        'estradiolUnit': 'pg/mL',
+        'testosteroneLevels': '1.67',
+        'testosteroneUnit': 'ng/dL',
+      });
+
+      final test =
+          await db.query('blood_tests', where: 'id = ?', whereArgs: [id]);
+
+      expect([
+        test.first['estradiolLevels'],
+        test.first['estradiolUnit'],
+        test.first['testosteroneLevels'],
+        test.first['testosteroneUnit'],
+      ], [
+        '167.1',
+        'pg/mL',
+        '1.67',
+        'ng/dL',
+      ]);
+    });
   });
 }


### PR DESCRIPTION
### Description

Adds a setting to switch between recording and displaying in units commonly used in the US (pg/mL & ng/dL) and the rest of the world (pmol/L & nmol/L).

To prevent any surprising conversion issues all values are stored as the user has entered them, along with the unit used at the time. Any conversion happens as late as possible and only when necessary (i.e. when rendering the graph). I didn't look too closely to how levels were estimated for the graph based on scheduled data, instead opting to perform a conversion at the end. It may be possible to simplify depending on what unit assumptions are made there.

Only one toggle is implements as it's expected for these unit differences to go together. They could be split out if it's important.

The default is set the US-centric units for backwards compatibility. Though, it may be worth considering changing the default as long we ensure previously entered data is correct and we don't surprise existing users.

Related to issue(s): #129

### Type of change
<!--- What types of changes does your code introduce? Keep all the lines that apply: -->
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

### Screenshots (if appropriate):
<img width="420" alt="Screenshot_20260501_145812" src="https://github.com/user-attachments/assets/cc1a1235-8c59-4f3f-a885-c60a243354e7" />
<img width="420" alt="Screenshot_20260501_145832" src="https://github.com/user-attachments/assets/e1fb3314-34bb-4f79-88b1-c06691f032f8" />
<img width="420" alt="Screenshot_20260501_145845" src="https://github.com/user-attachments/assets/0c8f6344-3359-4fdb-9eca-fb7ccacd8b1c" />
<img width="420" alt="Screenshot_20260501_150414" src="https://github.com/user-attachments/assets/600d3a8b-2626-4c3e-a3c2-3acf1e2d4973" />
<img width="420" alt="Screenshot_20260501_145852" src="https://github.com/user-attachments/assets/1ebeccb0-351f-427b-a4a2-4f743c2a6cfc" />


