### PR TITLE
build: devcontainer support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "https://raw.githubusercontent.com/devcontainers/spec/refs/heads/main/schemas/devContainer.schema.json",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "Dart-Code.dart-code",
+                "Dart-Code.flutter"
+            ]
+        }
+    },
+    "build": {
+        "dockerfile": "../Containerfile",
+        "context": "..",
+        "target": "development"
+    },
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "configureZshAsDefaultShell": true,
+            "installZsh": true
+        },
+        "ghcr.io/devcontainers/features/git:1": {}
+    },
+    "user": "vscode",
+    "onCreateCommand": {
+        "take ownership": "sudo chown vscode:vscode /opt -Rc"
+    }
+}

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,52 @@
+# --- BEGIN THIRD-PARTY CODE NOTICE ---
+# The snippet below is taken directly from the Flutter Version Manager project,
+# which is licensed under the MIT license. Below is a copy of that license
+# and it's notice. The modificatiions include changing the build stage;
+# stripping out (rather unnecessary for our use) comments, and changing the
+# source that it's copied from. Source file: FVM/.docker/Dockerfile
+# 
+# MIT License
+# 
+# Copyright (c) 2019 Leo Farias
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# --- END THIRD-PARTY CODE NOTICE ---
+# --- BEGIN THIRD-PARTY CODE ---
+FROM docker.io/library/dart:stable AS fvm
+
+WORKDIR /app
+ADD https://github.com/leoafarias/fvm.git#v4.1.0 .
+RUN dart pub get --no-precompile
+RUN apt-get update && apt-get install -y curl git unzip xz-utils zip \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir /out
+RUN dart compile exe bin/main.dart -o /out/fvm
+RUN /out/fvm --version
+# --- END THIRD-PARTY CODE ---
+
+FROM docker.io/library/fedora:latest AS development
+
+# install OpenJDK, CMake; Copy FVM and the SDK.
+RUN dnf in java-25-openjdk-devel java-25-openjdk java-25-openjdk-src \
+    --assumeyes
+COPY --from=fvm /out/fvm /usr/bin/fvm
+COPY --from=docker.io/runmymind/docker-android-sdk:latest \
+    /opt/android-sdk-linux /opt/android-sdk-linux
+ENV ANDROID_HOME=/opt/android-sdk-linux
+USER vscode

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,5 +1,67 @@
-Mona stores all user data locally on your device. No data is transmitted to external servers.
+# Privacy Policy
 
-User data is retained on the device until the user chooses to delete it. Users can delete their data at any time by clearing the app’s data or by uninstalling the application.
+## Introduction
 
-As an open-source application, Mona is fully transparent, and users remain in full control of their data at all times.
+Mona respects your privacy.
+
+This application is designed to operate entirely on your device. Mona does not collect, store, transmit, share, or sell personal data.
+
+## Data Collection
+
+Mona does not collect any personal information or user data.
+
+All data created or used by the application is stored locally on the user’s device only.
+
+Mona does NOT:
+- create user accounts;
+- track users;
+- use analytics services;
+- use advertising SDKs;
+- collect location data;
+- collect contacts;
+- collect device identifiers;
+- transmit data to external servers.
+
+## Data Storage
+
+All application data remains stored locally on your device.
+
+No user data is uploaded to cloud services or external servers by Mona.
+
+## Data Sharing
+
+Mona does not share any user data with third parties because no user data is collected or transmitted.
+
+## Data Retention
+
+Since data is stored locally on the device only, users retain full control over their data.
+
+Data remains on the device until the user deletes it.
+
+## Data Deletion
+
+Users can delete their data at any time by:
+- clearing the application data through the device settings; or
+- uninstalling the application.
+
+Once the application data is cleared or the application is uninstalled, all locally stored data is permanently deleted from the device.
+
+## Security
+
+Because Mona stores data locally and does not transmit information externally, users maintain direct control over their data security.
+
+## Children’s Privacy
+
+Mona does not knowingly collect personal information from children or any users.
+
+## Open Source
+
+Mona is an open-source application. Its source code can be publicly reviewed for transparency regarding privacy and data handling practices.
+
+## Changes to This Privacy Policy
+
+This Privacy Policy may be updated from time to time. Any changes will be reflected on this page.
+
+## Contact
+
+If you have questions about this Privacy Policy, you may contact the developers through the project repository.

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 #Mon Dec 29 10:58:08 CET 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-all.zip
+distributionSha256Sum=a3c4ba4aca8f0075688b9c5b18939fd28e8cb4357c227da5c1d9f38343791439
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Adds support for <https://containers.dev/>.

### Description
Adds a development container with Android SDK and FVM. Doing this lets those on immutable systems, or otherwise different environments simply bootstrap a temporary development environment. This also [theoretically] allows [/ should allow] easily deploying an environment in i.e. <https://vscode.dev>, letting potentially more people access the software. This also slightly helps with pollution of home directory for those that will not use the Flutter and/or Android SDKs. **This change also includes a gradle bump** from another PR, in case this one is undesired but a gradle bump still is.

### Type of change
- Maintenance