### PR TITLE
fix: add singular forms to schedules created text

### DIFF
--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -55,7 +55,7 @@
     "general": "General",
     "schedules": "Horarios",
     "noSchedules": "Sin horarios",
-    "schedulesCreated": "{count} creados",
+    "schedulesCreated": "{count, plural, =1{{count} creado} other{{count} creados}}",
     "language": "Idioma",
     "languageFollowDevice": "Seguir el idioma del dispositivo",
     "selectLanguage": "Seleccionar idioma",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -55,7 +55,7 @@
   "general": "Général",
   "schedules": "Plannings",
   "noSchedules": "Aucun planning",
-  "schedulesCreated": "{count} créés",
+  "schedulesCreated": "{count, plural, =1{{count} créé} other{{count} créés}}",
   "language": "Langue",
   "languageFollowDevice": "Suivre la langue de l’appareil",
   "selectLanguage": "Sélectionner la langue",

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -161,7 +161,13 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String schedulesCreated(num count) {
-    return '$count creados';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count creados',
+      one: '$count creado',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -162,7 +162,13 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String schedulesCreated(num count) {
-    return '$count créés';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count créés',
+      one: '$count créé',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -161,7 +161,13 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String schedulesCreated(num count) {
-    return '$count criados';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count criados',
+      one: '$count criado',
+    );
+    return '$_temp0';
   }
 
   @override
@@ -912,7 +918,13 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String schedulesCreated(num count) {
-    return '$count criados';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count criados',
+      one: '$count criado',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -164,7 +164,14 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String schedulesCreated(num count) {
-    return '$count створено';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Створено $count розкладів',
+      few: 'Створено $count розклади',
+      one: 'Створено $count розклад',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -55,7 +55,7 @@
     "general": "Geral",
     "schedules": "Cronogramas",
     "noSchedules": "Sem cronogramas",
-    "schedulesCreated": "{count} criados",
+    "schedulesCreated": "{count, plural, =1{{count} criado} other{{count} criados}}",
     "language": "Idioma",
     "languageFollowDevice": "Seguir o idioma do dispositivo",
     "selectLanguage": "Selecionar idioma",

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -55,7 +55,7 @@
     "general": "Geral",
     "schedules": "Cronogramas",
     "noSchedules": "Sem cronogramas",
-    "schedulesCreated": "{count} criados",
+    "schedulesCreated": "{count, plural, =1{{count} criado} other{{count} criados}}",
     "language": "Idioma",
     "languageFollowDevice": "Seguir o idioma do dispositivo",
     "selectLanguage": "Selecionar idioma",

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -55,7 +55,7 @@
   "general": "Загальне",
   "schedules": "Розклад",
   "noSchedules": "Розкладів немає",
-  "schedulesCreated": "{count} створено",
+  "schedulesCreated": "{count, plural, one{Створено {count} розклад} few{Створено {count} розклади} other{Створено {count} розкладів}}",
   "language": "Мова",
   "languageFollowDevice": "Мова пристрою",
   "selectLanguage": "Вибрати мову",


### PR DESCRIPTION
### Description
before : `1 créés`
after : `1 créé`

Related to issue(s): #173 

### Type of change
- Bug fix (non-breaking change which fixes an issue)

### Screenshots:
<img width="1080" height="603" alt="flutter_01" src="https://github.com/user-attachments/assets/491f6c38-c289-4e94-a4d6-a2eb408626cb" />