### PR TITLE
fix: calculate graph start and end using graph intakes only

### DIFF
--- a/lib/controllers/notification_scheduler.dart
+++ b/lib/controllers/notification_scheduler.dart
@@ -22,8 +22,8 @@ class NotificationScheduler {
     final now = DateTime.now();
 
     for (final schedule in medicationScheduleProvider.schedules) {
-      final lastTaken =
-          medicationIntakeProvider.getLastIntakeDateForSchedule(schedule.id);
+      final lastTaken = medicationIntakeProvider
+          .getLastIntakeLocalDateForSchedule(schedule.id);
       final nextDates = schedule.getNextDates(5);
 
       for (final date in nextDates) {

--- a/lib/controllers/schedule_manager.dart
+++ b/lib/controllers/schedule_manager.dart
@@ -15,8 +15,8 @@ class ScheduleManager {
   List<MedicationSchedule> getSchedulesByStatus(ScheduleStatus status) {
     final List<MedicationSchedule> schedules = [];
     for (final schedule in _medicationScheduleProvider.schedules) {
-      final Date? lastTaken =
-          _medicationIntakeProvider.getLastIntakeDateForSchedule(schedule.id);
+      final Date? lastTaken = _medicationIntakeProvider
+          .getLastIntakeLocalDateForSchedule(schedule.id);
 
       switch (status) {
         case ScheduleStatus.today:

--- a/lib/data/providers/medication_intake_provider.dart
+++ b/lib/data/providers/medication_intake_provider.dart
@@ -87,7 +87,7 @@ class MedicationIntakeProvider extends ChangeNotifier {
   Map<int, GraphIntake> getDaysAndIntakes() {
     if (graphIntakes.isEmpty) return {};
 
-    final startDate = getFirstIntakeLocalDate()!;
+    final startDate = getFirstGraphIntakeLocalDate()!;
     return Map.fromEntries(
       graphIntakes.map(
         (intake) => MapEntry(
@@ -98,15 +98,15 @@ class MedicationIntakeProvider extends ChangeNotifier {
     );
   }
 
-  Date? getFirstIntakeLocalDate() {
-    if (takenIntakes.isEmpty) return null;
+  Date? getFirstGraphIntakeLocalDate() {
+    if (graphIntakes.isEmpty) return null;
 
-    return takenIntakes
+    return graphIntakes
         .reduce((a, b) => a.takenDateTime!.isBefore(b.takenDateTime!) ? a : b)
         .takenLocalDate;
   }
 
-  Date? getLastIntakeDateFromList(List<MedicationIntake> intakes) {
+  Date? getLastIntakeLocalDateFromList(List<MedicationIntake> intakes) {
     if (intakes.isEmpty) return null;
 
     return intakes
@@ -114,13 +114,13 @@ class MedicationIntakeProvider extends ChangeNotifier {
         .takenLocalDate;
   }
 
-  Date? getLastIntakeDate() {
-    return getLastIntakeDateFromList(takenIntakes);
+  Date? getLastGraphIntakeDate() {
+    return getLastIntakeLocalDateFromList(graphIntakes);
   }
 
-  Date? getLastIntakeDateForSchedule(int scheduleId) {
+  Date? getLastIntakeLocalDateForSchedule(int scheduleId) {
     final scheduleIntakes = getTakenIntakesForSchedule(scheduleId);
-    return getLastIntakeDateFromList(scheduleIntakes);
+    return getLastIntakeLocalDateFromList(scheduleIntakes);
   }
 
   MedicationIntake? getLastTakenIntake() {

--- a/lib/ui/views/chart/chart_graph.dart
+++ b/lib/ui/views/chart/chart_graph.dart
@@ -36,16 +36,17 @@ class MainGraph extends StatelessWidget {
     final bloodTestProvider = context.watch<BloodTestProvider>();
     final theme = Theme.of(context);
     final l10n = context.l10n;
-    final Date firstDay = medicationIntakeProvider.getFirstIntakeLocalDate()!;
     final unit = preferencesProvider.units.estradiol;
 
     Map<int, GraphIntake> daysAndIntakes =
         medicationIntakeProvider.getDaysAndIntakes();
 
+    if (daysAndIntakes.isEmpty) return SizedBox.shrink();
+
+    final Date firstDay =
+        medicationIntakeProvider.getFirstGraphIntakeLocalDate()!;
     Map<int, double> daysAndBloodTests =
         bloodTestProvider.getDaysAndBloodTests(firstDay, unit);
-
-    if (daysAndIntakes.isEmpty) return SizedBox.shrink();
 
     final List<FlSpot> spots =
         GraphCalculator().generateFlSpots(daysAndIntakes, unit);
@@ -55,7 +56,7 @@ class MainGraph extends StatelessWidget {
         .toList();
 
     final int totalDays = medicationIntakeProvider
-        .getLastIntakeDate()!
+        .getLastGraphIntakeDate()!
         .differenceInDays(firstDay);
     final double daysSinceStart =
         DateTime.now().difference(firstDay.toDateTime()).inSeconds / 86400.0;

--- a/lib/ui/views/home/intake_tile.dart
+++ b/lib/ui/views/home/intake_tile.dart
@@ -137,7 +137,7 @@ class IntakeTileViewModel {
   Date? get lastScheduled => schedule.previousDate;
 
   Date? get lastTaken =>
-      intakeProvider.getLastIntakeDateForSchedule(schedule.id);
+      intakeProvider.getLastIntakeLocalDateForSchedule(schedule.id);
 
   int get daysUntilIntake => nextScheduled.daysAwayFromToday;
 

--- a/test/controllers/medication_intake_manager_test.mocks.dart
+++ b/test/controllers/medication_intake_manager_test.mocks.dart
@@ -185,20 +185,21 @@ class MockMedicationIntakeProvider extends _i1.Mock
       ) as Map<int, _i3.GraphIntake>);
 
   @override
-  _i6.Date? getLastIntakeDateFromList(List<_i4.MedicationIntake>? intakes) =>
+  _i6.Date? getLastIntakeLocalDateFromList(
+          List<_i4.MedicationIntake>? intakes) =>
       (super.noSuchMethod(
         Invocation.method(
-          #getLastIntakeDateFromList,
+          #getLastIntakeLocalDateFromList,
           [intakes],
         ),
         returnValueForMissingStub: null,
       ) as _i6.Date?);
 
   @override
-  _i6.Date? getLastIntakeDateForSchedule(int? scheduleId) =>
+  _i6.Date? getLastIntakeLocalDateForSchedule(int? scheduleId) =>
       (super.noSuchMethod(
         Invocation.method(
-          #getLastIntakeDateForSchedule,
+          #getLastIntakeLocalDateForSchedule,
           [scheduleId],
         ),
         returnValueForMissingStub: null,

--- a/test/controllers/notification_scheduler_test.dart
+++ b/test/controllers/notification_scheduler_test.dart
@@ -213,7 +213,7 @@ void main() {
           )
         ]);
         when(mockMedicationIntakeProvider
-                .getLastIntakeDateForSchedule(scheduleId))
+                .getLastIntakeLocalDateForSchedule(scheduleId))
             .thenReturn(null);
 
         final scheduler = NotificationScheduler(
@@ -266,7 +266,7 @@ void main() {
           )
         ]);
         when(mockMedicationIntakeProvider
-                .getLastIntakeDateForSchedule(scheduleId))
+                .getLastIntakeLocalDateForSchedule(scheduleId))
             .thenReturn(null);
 
         final scheduler = NotificationScheduler(
@@ -330,7 +330,7 @@ void main() {
           )
         ]);
         when(mockMedicationIntakeProvider
-                .getLastIntakeDateForSchedule(scheduleId))
+                .getLastIntakeLocalDateForSchedule(scheduleId))
             .thenReturn(null);
 
         final scheduler = NotificationScheduler(
@@ -397,7 +397,7 @@ void main() {
           )
         ]);
         when(mockMedicationIntakeProvider
-                .getLastIntakeDateForSchedule(scheduleId))
+                .getLastIntakeLocalDateForSchedule(scheduleId))
             .thenReturn(null);
 
         final scheduler = NotificationScheduler(
@@ -450,7 +450,7 @@ void main() {
 
         when(mockPreferencesService.notificationsEnabled).thenReturn(true);
         when(mockMedicationIntakeProvider
-                .getLastIntakeDateForSchedule(scheduleId))
+                .getLastIntakeLocalDateForSchedule(scheduleId))
             .thenReturn(Date.today());
         when(mockMedicationScheduleProvider.schedules).thenReturn([
           MedicationSchedule(

--- a/test/controllers/notification_scheduler_test.mocks.dart
+++ b/test/controllers/notification_scheduler_test.mocks.dart
@@ -7,26 +7,27 @@ import 'dart:async' as _i5;
 import 'dart:ui' as _i6;
 
 import 'package:flutter_local_notifications/src/flutter_local_notifications_plugin.dart'
-    as _i12;
-import 'package:flutter_local_notifications/src/initialization_settings.dart'
     as _i13;
-import 'package:flutter_local_notifications/src/notification_details.dart'
-    as _i15;
-import 'package:flutter_local_notifications/src/platform_specifics/android/schedule_mode.dart'
-    as _i17;
-import 'package:flutter_local_notifications/src/types.dart' as _i18;
-import 'package:flutter_local_notifications_platform_interface/flutter_local_notifications_platform_interface.dart'
+import 'package:flutter_local_notifications/src/initialization_settings.dart'
     as _i14;
+import 'package:flutter_local_notifications/src/notification_details.dart'
+    as _i16;
+import 'package:flutter_local_notifications/src/platform_specifics/android/schedule_mode.dart'
+    as _i18;
+import 'package:flutter_local_notifications/src/types.dart' as _i19;
+import 'package:flutter_local_notifications_platform_interface/flutter_local_notifications_platform_interface.dart'
+    as _i15;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mona/data/model/date.dart' as _i9;
 import 'package:mona/data/model/medication_intake.dart' as _i8;
 import 'package:mona/data/model/medication_schedule.dart' as _i4;
-import 'package:mona/data/model/molecule.dart' as _i11;
+import 'package:mona/data/model/molecule.dart' as _i12;
+import 'package:mona/data/model/units.dart' as _i11;
 import 'package:mona/data/providers/medication_intake_provider.dart' as _i7;
 import 'package:mona/data/providers/medication_schedule_provider.dart' as _i3;
 import 'package:mona/services/preferences_service.dart' as _i10;
 import 'package:mona/services/repository.dart' as _i2;
-import 'package:timezone/timezone.dart' as _i16;
+import 'package:timezone/timezone.dart' as _i17;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -331,20 +332,21 @@ class MockMedicationIntakeProvider extends _i1.Mock
       ) as Map<int, _i7.GraphIntake>);
 
   @override
-  _i9.Date? getLastIntakeDateFromList(List<_i8.MedicationIntake>? intakes) =>
+  _i9.Date? getLastIntakeLocalDateFromList(
+          List<_i8.MedicationIntake>? intakes) =>
       (super.noSuchMethod(
         Invocation.method(
-          #getLastIntakeDateFromList,
+          #getLastIntakeLocalDateFromList,
           [intakes],
         ),
         returnValueForMissingStub: null,
       ) as _i9.Date?);
 
   @override
-  _i9.Date? getLastIntakeDateForSchedule(int? scheduleId) =>
+  _i9.Date? getLastIntakeLocalDateForSchedule(int? scheduleId) =>
       (super.noSuchMethod(
         Invocation.method(
-          #getLastIntakeDateForSchedule,
+          #getLastIntakeLocalDateForSchedule,
           [scheduleId],
         ),
         returnValueForMissingStub: null,
@@ -407,18 +409,25 @@ class MockPreferencesService extends _i1.Mock
       ) as bool);
 
   @override
-  List<_i11.Molecule> get customMolecules => (super.noSuchMethod(
-        Invocation.getter(#customMolecules),
-        returnValue: <_i11.Molecule>[],
-        returnValueForMissingStub: <_i11.Molecule>[],
-      ) as List<_i11.Molecule>);
+  _i11.Units get units => (super.noSuchMethod(
+        Invocation.getter(#units),
+        returnValue: _i11.Units.pg_mL_ng_dL,
+        returnValueForMissingStub: _i11.Units.pg_mL_ng_dL,
+      ) as _i11.Units);
 
   @override
-  List<_i11.Molecule> get allMolecules => (super.noSuchMethod(
+  List<_i12.Molecule> get customMolecules => (super.noSuchMethod(
+        Invocation.getter(#customMolecules),
+        returnValue: <_i12.Molecule>[],
+        returnValueForMissingStub: <_i12.Molecule>[],
+      ) as List<_i12.Molecule>);
+
+  @override
+  List<_i12.Molecule> get allMolecules => (super.noSuchMethod(
         Invocation.getter(#allMolecules),
-        returnValue: <_i11.Molecule>[],
-        returnValueForMissingStub: <_i11.Molecule>[],
-      ) as List<_i11.Molecule>);
+        returnValue: <_i12.Molecule>[],
+        returnValueForMissingStub: <_i12.Molecule>[],
+      ) as List<_i12.Molecule>);
 
   @override
   bool get hasListeners => (super.noSuchMethod(
@@ -460,7 +469,17 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> addCustomMolecule(_i11.Molecule? molecule) =>
+  _i5.Future<void> setUnits(_i11.Units? units) => (super.noSuchMethod(
+        Invocation.method(
+          #setUnits,
+          [units],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> addCustomMolecule(_i12.Molecule? molecule) =>
       (super.noSuchMethod(
         Invocation.method(
           #addCustomMolecule,
@@ -521,13 +540,13 @@ class MockPreferencesService extends _i1.Mock
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockFlutterLocalNotificationsPlugin extends _i1.Mock
-    implements _i12.FlutterLocalNotificationsPlugin {
+    implements _i13.FlutterLocalNotificationsPlugin {
   @override
   _i5.Future<bool?> initialize({
-    required _i13.InitializationSettings? settings,
-    _i14.DidReceiveNotificationResponseCallback?
+    required _i14.InitializationSettings? settings,
+    _i15.DidReceiveNotificationResponseCallback?
         onDidReceiveNotificationResponse,
-    _i14.DidReceiveBackgroundNotificationResponseCallback?
+    _i15.DidReceiveBackgroundNotificationResponseCallback?
         onDidReceiveBackgroundNotificationResponse,
   }) =>
       (super.noSuchMethod(
@@ -546,23 +565,23 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
       ) as _i5.Future<bool?>);
 
   @override
-  _i5.Future<_i14.NotificationAppLaunchDetails?>
+  _i5.Future<_i15.NotificationAppLaunchDetails?>
       getNotificationAppLaunchDetails() => (super.noSuchMethod(
             Invocation.method(
               #getNotificationAppLaunchDetails,
               [],
             ),
-            returnValue: _i5.Future<_i14.NotificationAppLaunchDetails?>.value(),
+            returnValue: _i5.Future<_i15.NotificationAppLaunchDetails?>.value(),
             returnValueForMissingStub:
-                _i5.Future<_i14.NotificationAppLaunchDetails?>.value(),
-          ) as _i5.Future<_i14.NotificationAppLaunchDetails?>);
+                _i5.Future<_i15.NotificationAppLaunchDetails?>.value(),
+          ) as _i5.Future<_i15.NotificationAppLaunchDetails?>);
 
   @override
   _i5.Future<void> show({
     required int? id,
     String? title,
     String? body,
-    _i15.NotificationDetails? notificationDetails,
+    _i16.NotificationDetails? notificationDetails,
     String? payload,
   }) =>
       (super.noSuchMethod(
@@ -622,13 +641,13 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
   @override
   _i5.Future<void> zonedSchedule({
     required int? id,
-    required _i16.TZDateTime? scheduledDate,
-    required _i15.NotificationDetails? notificationDetails,
-    required _i17.AndroidScheduleMode? androidScheduleMode,
+    required _i17.TZDateTime? scheduledDate,
+    required _i16.NotificationDetails? notificationDetails,
+    required _i18.AndroidScheduleMode? androidScheduleMode,
     String? title,
     String? body,
     String? payload,
-    _i18.DateTimeComponents? matchDateTimeComponents,
+    _i19.DateTimeComponents? matchDateTimeComponents,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -652,9 +671,9 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
   @override
   _i5.Future<void> periodicallyShow({
     required int? id,
-    required _i14.RepeatInterval? repeatInterval,
-    required _i15.NotificationDetails? notificationDetails,
-    required _i17.AndroidScheduleMode? androidScheduleMode,
+    required _i15.RepeatInterval? repeatInterval,
+    required _i16.NotificationDetails? notificationDetails,
+    required _i18.AndroidScheduleMode? androidScheduleMode,
     String? title,
     String? body,
     String? payload,
@@ -681,11 +700,11 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
   _i5.Future<void> periodicallyShowWithDuration({
     required int? id,
     required Duration? repeatDurationInterval,
-    required _i15.NotificationDetails? notificationDetails,
+    required _i16.NotificationDetails? notificationDetails,
     String? title,
     String? body,
-    _i17.AndroidScheduleMode? androidScheduleMode =
-        _i17.AndroidScheduleMode.exact,
+    _i18.AndroidScheduleMode? androidScheduleMode =
+        _i18.AndroidScheduleMode.exact,
     String? payload,
   }) =>
       (super.noSuchMethod(
@@ -707,31 +726,31 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<List<_i14.PendingNotificationRequest>>
+  _i5.Future<List<_i15.PendingNotificationRequest>>
       pendingNotificationRequests() => (super.noSuchMethod(
             Invocation.method(
               #pendingNotificationRequests,
               [],
             ),
             returnValue:
-                _i5.Future<List<_i14.PendingNotificationRequest>>.value(
-                    <_i14.PendingNotificationRequest>[]),
+                _i5.Future<List<_i15.PendingNotificationRequest>>.value(
+                    <_i15.PendingNotificationRequest>[]),
             returnValueForMissingStub:
-                _i5.Future<List<_i14.PendingNotificationRequest>>.value(
-                    <_i14.PendingNotificationRequest>[]),
-          ) as _i5.Future<List<_i14.PendingNotificationRequest>>);
+                _i5.Future<List<_i15.PendingNotificationRequest>>.value(
+                    <_i15.PendingNotificationRequest>[]),
+          ) as _i5.Future<List<_i15.PendingNotificationRequest>>);
 
   @override
-  _i5.Future<List<_i14.ActiveNotification>> getActiveNotifications() =>
+  _i5.Future<List<_i15.ActiveNotification>> getActiveNotifications() =>
       (super.noSuchMethod(
         Invocation.method(
           #getActiveNotifications,
           [],
         ),
-        returnValue: _i5.Future<List<_i14.ActiveNotification>>.value(
-            <_i14.ActiveNotification>[]),
+        returnValue: _i5.Future<List<_i15.ActiveNotification>>.value(
+            <_i15.ActiveNotification>[]),
         returnValueForMissingStub:
-            _i5.Future<List<_i14.ActiveNotification>>.value(
-                <_i14.ActiveNotification>[]),
-      ) as _i5.Future<List<_i14.ActiveNotification>>);
+            _i5.Future<List<_i15.ActiveNotification>>.value(
+                <_i15.ActiveNotification>[]),
+      ) as _i5.Future<List<_i15.ActiveNotification>>);
 }

--- a/test/controllers/schedule_manager_test.dart
+++ b/test/controllers/schedule_manager_test.dart
@@ -51,7 +51,7 @@ void main() {
         administrationRoute: AdministrationRoute.oral,
         notificationTimes: List.empty(),
       );
-      when(mockIntakeProvider.getLastIntakeDateForSchedule(1))
+      when(mockIntakeProvider.getLastIntakeLocalDateForSchedule(1))
           .thenReturn(today.subtract(const Duration(days: 2)));
 
       todayTakenSchedule = MedicationSchedule(
@@ -64,7 +64,7 @@ void main() {
         administrationRoute: AdministrationRoute.oral,
         notificationTimes: List.empty(),
       );
-      when(mockIntakeProvider.getLastIntakeDateForSchedule(5))
+      when(mockIntakeProvider.getLastIntakeLocalDateForSchedule(5))
           .thenReturn(Date.today());
 
       todayOverdueSchedule = MedicationSchedule(
@@ -77,7 +77,7 @@ void main() {
         administrationRoute: AdministrationRoute.oral,
         notificationTimes: List.empty(),
       );
-      when(mockIntakeProvider.getLastIntakeDateForSchedule(4))
+      when(mockIntakeProvider.getLastIntakeLocalDateForSchedule(4))
           .thenReturn(today.subtract(const Duration(days: 3)));
 
       overdueSchedule = MedicationSchedule(
@@ -90,7 +90,7 @@ void main() {
         administrationRoute: AdministrationRoute.oral,
         notificationTimes: List.empty(),
       );
-      when(mockIntakeProvider.getLastIntakeDateForSchedule(2))
+      when(mockIntakeProvider.getLastIntakeLocalDateForSchedule(2))
           .thenReturn(today.subtract(const Duration(days: 4)));
 
       upcomingSchedule = MedicationSchedule(
@@ -103,7 +103,8 @@ void main() {
         administrationRoute: AdministrationRoute.oral,
         notificationTimes: List.empty(),
       );
-      when(mockIntakeProvider.getLastIntakeDateForSchedule(3)).thenReturn(null);
+      when(mockIntakeProvider.getLastIntakeLocalDateForSchedule(3))
+          .thenReturn(null);
 
       when(mockScheduleProvider.schedules).thenReturn([
         todaySchedule,
@@ -128,7 +129,7 @@ void main() {
         notificationTimes: List.empty(),
       );
 
-      when(mockIntakeProvider.getLastIntakeDateForSchedule(1))
+      when(mockIntakeProvider.getLastIntakeLocalDateForSchedule(1))
           .thenReturn(today.subtract(const Duration(days: 2)));
 
       final result = manager.getSchedulesByStatus(ScheduleStatus.today);

--- a/test/controllers/schedule_manager_test.mocks.dart
+++ b/test/controllers/schedule_manager_test.mocks.dart
@@ -317,20 +317,21 @@ class MockMedicationIntakeProvider extends _i1.Mock
       ) as Map<int, _i7.GraphIntake>);
 
   @override
-  _i9.Date? getLastIntakeDateFromList(List<_i8.MedicationIntake>? intakes) =>
+  _i9.Date? getLastIntakeLocalDateFromList(
+          List<_i8.MedicationIntake>? intakes) =>
       (super.noSuchMethod(
         Invocation.method(
-          #getLastIntakeDateFromList,
+          #getLastIntakeLocalDateFromList,
           [intakes],
         ),
         returnValueForMissingStub: null,
       ) as _i9.Date?);
 
   @override
-  _i9.Date? getLastIntakeDateForSchedule(int? scheduleId) =>
+  _i9.Date? getLastIntakeLocalDateForSchedule(int? scheduleId) =>
       (super.noSuchMethod(
         Invocation.method(
-          #getLastIntakeDateForSchedule,
+          #getLastIntakeLocalDateForSchedule,
           [scheduleId],
         ),
         returnValueForMissingStub: null,

--- a/test/data/providers/medication_intake_provider_test.dart
+++ b/test/data/providers/medication_intake_provider_test.dart
@@ -222,7 +222,7 @@ void main() {
 
     group('getLastIntakeDateFromList', () {
       test('returns null if the list is empty', () {
-        final result = provider.getLastIntakeDateFromList([]);
+        final result = provider.getLastIntakeLocalDateFromList([]);
         expect(result, isNull);
       });
 
@@ -238,7 +238,7 @@ void main() {
           administrationRoute: AdministrationRoute.gel,
         );
 
-        final result = provider.getLastIntakeDateFromList([intake]);
+        final result = provider.getLastIntakeLocalDateFromList([intake]);
         expect(result, intake.takenLocalDate);
       });
 
@@ -276,8 +276,8 @@ void main() {
           administrationRoute: AdministrationRoute.gel,
         );
 
-        final result =
-            provider.getLastIntakeDateFromList([intake1, intake2, intake3]);
+        final result = provider
+            .getLastIntakeLocalDateFromList([intake1, intake2, intake3]);
         expect(result, intake3.takenLocalDate);
       });
 
@@ -305,7 +305,8 @@ void main() {
           administrationRoute: AdministrationRoute.gel,
         );
 
-        final result = provider.getLastIntakeDateFromList([intake1, intake2]);
+        final result =
+            provider.getLastIntakeLocalDateFromList([intake1, intake2]);
         expect(result, intake1.takenLocalDate);
       });
     });

--- a/test/mocks/mocks.mocks.dart
+++ b/test/mocks/mocks.mocks.dart
@@ -345,16 +345,17 @@ class MockMedicationIntakeProvider extends _i1.Mock
       ) as Map<int, _i12.GraphIntake>);
 
   @override
-  _i14.Date? getLastIntakeDateFromList(List<_i13.MedicationIntake>? intakes) =>
+  _i14.Date? getLastIntakeLocalDateFromList(
+          List<_i13.MedicationIntake>? intakes) =>
       (super.noSuchMethod(Invocation.method(
-        #getLastIntakeDateFromList,
+        #getLastIntakeLocalDateFromList,
         [intakes],
       )) as _i14.Date?);
 
   @override
-  _i14.Date? getLastIntakeDateForSchedule(int? scheduleId) =>
+  _i14.Date? getLastIntakeLocalDateForSchedule(int? scheduleId) =>
       (super.noSuchMethod(Invocation.method(
-        #getLastIntakeDateForSchedule,
+        #getLastIntakeLocalDateForSchedule,
         [scheduleId],
       )) as _i14.Date?);
 


### PR DESCRIPTION
### Description
The graph x axis was using all taken intakes to calculate the start and end, resulting in a minor visual glitch. It's now fixed.

Related to issue(s): # (issue)

### Type of change
- Bug fix (non-breaking change which fixes an issue)
- 
### Screenshots (if appropriate):
before
<img width="1080" height="1083" alt="1000038975" src="https://github.com/user-attachments/assets/7d255c2a-832b-4400-8de5-4be7b8e1d81f" />
after
<img width="1080" height="1050" alt="flutter_02" src="https://github.com/user-attachments/assets/0d01a8ca-d6b7-420b-b190-be9d88c9419e" />