### PR TITLE
chore: remove legacy builds from ci

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -195,72 +195,11 @@ jobs:
           path: build/app/outputs/flutter-apk/mona-*.apk
           retention-days: 7
 
-  # ── Build Android release APK — legacy (unsigned, no secrets) ─────────────
-  build_android_legacy:
-    name: Build Android APK (legacy, unsigned)
-    runs-on: ubuntu-latest
-    needs: [bump_version]
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          ref: main
-
-      - name: Set up Java 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: "17"
-
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          channel: stable
-          flutter-version-file: .fvmrc
-          cache: true
-
-      - name: Get dependencies
-        run: flutter pub get
-
-      # Universal APK. Renamed to `app-universal-release.apk` so the in-app
-      # updater's `universal` fallback can pick it up.
-      - name: Build legacy APK (universal)
-        run: flutter build apk --release --flavor legacy
-
-      - name: Rename legacy universal APK
-        run: |
-          mv build/app/outputs/flutter-apk/app-legacy-release.apk \
-             build/app/outputs/flutter-apk/app-universal-release.apk
-
-      # Per-ABI APKs. Strip the `legacy-` segment so filenames match the ABI
-      # tokens (`arm64-v8a`, `armeabi-v7a`, `x86_64`) used by the in-app
-      # updater's ABI matcher.
-      - name: Build legacy APK (split per ABI)
-        run: flutter build apk --release --flavor legacy --split-per-abi
-
-      - name: Rename legacy split APKs
-        run: |
-          cd build/app/outputs/flutter-apk
-          for f in app-legacy-*-release.apk; do
-            [ -f "$f" ] || continue
-            mv "$f" "${f/app-legacy-/app-}"
-          done
-
-      - name: Upload legacy APK artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: android-release-apk-legacy
-          path: |
-            build/app/outputs/flutter-apk/app-universal-release.apk
-            build/app/outputs/flutter-apk/app-*-release.apk
-          retention-days: 7
-
   # ── GitHub Release ─────────────────────────────────────────────────────────
   create_release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [build_android_standalone, build_android_legacy]
+    needs: [build_android_standalone]
     permissions:
       contents: write
 
@@ -271,13 +210,7 @@ jobs:
           name: android-release-apk-standalone
           path: artifacts/
 
-      - name: Download legacy APK artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: android-release-apk-legacy
-          path: artifacts/
-
-      # Create the release and attach all APKs.
+      # Create the release and attach the APK.
       # The tag name becomes the release title (e.g. "v1.2.3").
       - name: Create release and upload APKs
         uses: softprops/action-gh-release@v2
@@ -286,5 +219,4 @@ jobs:
           name: ${{ github.ref_name }}
           files: |
             artifacts/mona-*.apk
-            artifacts/app-*-release.apk
           generate_release_notes: false


### PR DESCRIPTION
### Description
Due to signature problems, i'll publish the legacy builds manually as it's easier to do this way. These are deprecated anyways and will be dropped soon.

### Type of change
- Maintenance