### PR TITLE
feat: db IDs are now UUIDs

### DIFF
--- a/lib/data/model/blood_test.dart
+++ b/lib/data/model/blood_test.dart
@@ -5,21 +5,27 @@ import 'package:mona/util/string_parsing.dart';
 import 'package:mona/util/timezone_location.dart';
 import 'package:mona/util/validators.dart';
 import 'package:timezone/timezone.dart' as tz;
+import 'package:uuid/uuid.dart';
 
 class BloodTest {
-  final int id;
+  final String id;
   final DateTime dateTime;
   final String timeZone;
   final UnitValue<EstradiolUnit>? estradiolLevels;
   final UnitValue<TestosteroneUnit>? testosteroneLevels;
+  final int updatedAt;
+  final bool isDeleted;
 
   BloodTest({
-    int? id,
+    String? id,
     required this.dateTime,
     required this.timeZone,
     this.estradiolLevels,
     this.testosteroneLevels,
-  }) : id = id ?? DateTime.now().millisecondsSinceEpoch {
+    int? updatedAt,
+    this.isDeleted = false,
+  })  : id = id ?? const Uuid().v4(),
+        updatedAt = updatedAt ?? DateTime.now().millisecondsSinceEpoch {
     if (!dateTime.isUtc) {
       throw ArgumentError('dateTime must be UTC');
     }
@@ -39,7 +45,7 @@ class BloodTest {
         : null;
 
     return BloodTest(
-        id: map['id'] as int?,
+        id: map['id'] as String?,
         dateTime: (map['dateTime'] as String).toDateTime,
         timeZone: map['timeZone'] as String,
         estradiolLevels: estradiolLevels != null
@@ -47,7 +53,9 @@ class BloodTest {
             : null,
         testosteroneLevels: testosteroneLevels != null
             ? UnitValue(testosteroneLevels, testosteroneUnit!)
-            : null);
+            : null,
+        updatedAt: map['updatedAt'] as int?,
+        isDeleted: (map['isDeleted'] as int?) == 1);
   }
 
   DateTime get localDateTime {
@@ -58,11 +66,13 @@ class BloodTest {
   Date get localDate => localDateTime.toDate;
 
   BloodTest copyWith({
-    int? id,
+    String? id,
     DateTime? dateTime,
     String? timeZone,
     UnitValue<EstradiolUnit>? estradiolLevels,
     UnitValue<TestosteroneUnit>? testosteroneLevels,
+    int? updatedAt,
+    bool? isDeleted,
   }) {
     return BloodTest(
       id: id ?? this.id,
@@ -70,6 +80,8 @@ class BloodTest {
       timeZone: timeZone ?? this.timeZone,
       estradiolLevels: estradiolLevels ?? this.estradiolLevels,
       testosteroneLevels: testosteroneLevels ?? this.testosteroneLevels,
+      updatedAt: updatedAt ?? this.updatedAt,
+      isDeleted: isDeleted ?? this.isDeleted,
     );
   }
 
@@ -82,6 +94,8 @@ class BloodTest {
       'estradiolUnit': estradiolLevels?.unit.toString(),
       'testosteroneLevels': testosteroneLevels?.value.toString(),
       'testosteroneUnit': testosteroneLevels?.unit.toString(),
+      'updatedAt': updatedAt,
+      'isDeleted': isDeleted ? 1 : 0,
     };
   }
 

--- a/lib/data/model/generic_supply_item.dart
+++ b/lib/data/model/generic_supply_item.dart
@@ -9,7 +9,9 @@ class GenericSupply implements SupplyItem {
   @override
   final String name;
   final int amount;
+  @override
   final int updatedAt;
+  @override
   final bool isDeleted;
 
   GenericSupply({

--- a/lib/data/model/generic_supply_item.dart
+++ b/lib/data/model/generic_supply_item.dart
@@ -9,17 +9,21 @@ class GenericSupply implements SupplyItem {
   @override
   final String name;
   final int amount;
+  final int updatedAt;
+  final bool isDeleted;
 
   GenericSupply({
-    Stream? id,
+    String? id,
     required this.name,
     required this.amount,
-    
-  }) : id = id ?? DateTime.now().millisecondsSinceEpoch;
+    int? updatedAt,
+    this.isDeleted = false,
+  })  : id = id ?? const Uuid().v4(),
+        updatedAt = updatedAt ?? DateTime.now().millisecondsSinceEpoch;
 
   factory GenericSupply.fromMap(Map<String, Object?> map) {
     return GenericSupply(
-      id: map['id'] as int?,
+      id: map['id'] as String?,
       name: map['name'] as String,
       amount: map['amount'] as int,
     );
@@ -36,7 +40,7 @@ class GenericSupply implements SupplyItem {
   }
 
   GenericSupply copyWith({
-    int? id,
+    String? id,
     String? name,
     int? amount,
   }) {

--- a/lib/data/model/generic_supply_item.dart
+++ b/lib/data/model/generic_supply_item.dart
@@ -1,18 +1,20 @@
 import 'package:mona/data/model/supply_item.dart';
 import 'package:mona/l10n/app_localizations.dart';
 import 'package:mona/util/validators.dart';
+import 'package:uuid/uuid.dart';
 
 class GenericSupply implements SupplyItem {
   @override
-  final int id;
+  final String id;
   @override
   final String name;
   final int amount;
 
   GenericSupply({
-    int? id,
+    Stream? id,
     required this.name,
     required this.amount,
+    
   }) : id = id ?? DateTime.now().millisecondsSinceEpoch;
 
   factory GenericSupply.fromMap(Map<String, Object?> map) {

--- a/lib/data/model/medication_intake.dart
+++ b/lib/data/model/medication_intake.dart
@@ -11,6 +11,7 @@ import 'package:mona/util/string_parsing.dart';
 import 'package:mona/util/timezone_location.dart';
 import 'package:mona/util/validators.dart';
 import 'package:timezone/timezone.dart' as tz;
+import 'package:uuid/uuid.dart';
 
 part 'medication_intake.mapper.dart';
 
@@ -30,12 +31,12 @@ enum InjectionSide {
   generateMethods: GenerateMethods.all,
 )
 class MedicationIntake with MedicationIntakeMappable {
-  final int id;
+  final String id;
   final DateTime scheduledDateTime;
   final DateTime? takenDateTime;
   final String? takenTimeZone;
   final Decimal dose;
-  final int? scheduleId;
+  final String? scheduleId;
   final InjectionSide? side;
   bool get isTaken => takenDateTime != null;
   @MappableField(
@@ -45,11 +46,14 @@ class MedicationIntake with MedicationIntakeMappable {
   final AdministrationRoute administrationRoute;
   @MappableField(key: 'esterName')
   final Ester? ester;
-  final int? supplyItemId;
+  final String? supplyItemId;
   final String? notes;
+  final int updatedAt;
+  @MappableField(hook: BoolIntHook())
+  final bool isDeleted;
 
   MedicationIntake({
-    int? id,
+    String? id,
     required this.scheduledDateTime,
     required this.dose,
     this.takenDateTime,
@@ -61,7 +65,10 @@ class MedicationIntake with MedicationIntakeMappable {
     this.ester,
     this.supplyItemId,
     this.notes,
-  }) : id = id ?? DateTime.now().millisecondsSinceEpoch {
+    int? updatedAt,
+    this.isDeleted = false,
+  })  : id = id ?? const Uuid().v4(),
+        updatedAt = updatedAt ?? DateTime.now().millisecondsSinceEpoch {
     if (takenDateTime != null && !takenDateTime!.isUtc) {
       throw ArgumentError('takenDateTime must be UTC');
     }
@@ -152,5 +159,25 @@ class DecimalStringMapper extends SimpleMapper<Decimal> {
   @override
   Object? encode(Decimal self) {
     return self.toString();
+  }
+}
+
+class BoolIntHook extends MappingHook {
+  const BoolIntHook();
+
+  @override
+  Object? beforeDecode(Object? value) {
+    if (value is int) {
+      return value == 1;
+    }
+    return value;
+  }
+
+  @override
+  Object? afterEncode(Object? value) {
+    if (value is bool) {
+      return value ? 1 : 0;
+    }
+    return value;
   }
 }

--- a/lib/data/model/medication_intake.mapper.dart
+++ b/lib/data/model/medication_intake.mapper.dart
@@ -122,7 +122,7 @@ class MedicationIntakeMapper extends ClassMapperBase<MedicationIntake> {
   static AdministrationRoute _$administrationRoute(MedicationIntake v) =>
       v.administrationRoute;
   static const Field<MedicationIntake, AdministrationRoute>
-  _f$administrationRoute = Field(
+      _f$administrationRoute = Field(
     'administrationRoute',
     _$administrationRoute,
     key: r'administrationRouteName',
@@ -222,12 +222,12 @@ mixin MedicationIntakeMappable {
   }
 
   MedicationIntakeCopyWith<MedicationIntake, MedicationIntake, MedicationIntake>
-  get copyWith =>
-      _MedicationIntakeCopyWithImpl<MedicationIntake, MedicationIntake>(
-        this as MedicationIntake,
-        $identity,
-        $identity,
-      );
+      get copyWith =>
+          _MedicationIntakeCopyWithImpl<MedicationIntake, MedicationIntake>(
+            this as MedicationIntake,
+            $identity,
+            $identity,
+          );
   @override
   String toString() {
     return MedicationIntakeMapper.ensureInitialized().stringifyValue(
@@ -254,8 +254,8 @@ mixin MedicationIntakeMappable {
 extension MedicationIntakeValueCopy<$R, $Out>
     on ObjectCopyWith<$R, MedicationIntake, $Out> {
   MedicationIntakeCopyWith<$R, MedicationIntake, $Out>
-  get $asMedicationIntake =>
-      $base.as((v, t, t2) => _MedicationIntakeCopyWithImpl<$R, $Out>(v, t, t2));
+      get $asMedicationIntake => $base
+          .as((v, t, t2) => _MedicationIntakeCopyWithImpl<$R, $Out>(v, t, t2));
 }
 
 abstract class MedicationIntakeCopyWith<$R, $In extends MedicationIntake, $Out>
@@ -305,52 +305,53 @@ class _MedicationIntakeCopyWithImpl<$R, $Out>
     Object? notes = $none,
     Object? updatedAt = $none,
     bool? isDeleted,
-  }) => $apply(
-    FieldCopyWithData({
-      if (id != $none) #id: id,
-      if (scheduledDateTime != null) #scheduledDateTime: scheduledDateTime,
-      if (dose != null) #dose: dose,
-      if (takenDateTime != $none) #takenDateTime: takenDateTime,
-      if (takenTimeZone != $none) #takenTimeZone: takenTimeZone,
-      if (scheduleId != $none) #scheduleId: scheduleId,
-      if (side != $none) #side: side,
-      if (molecule != null) #molecule: molecule,
-      if (administrationRoute != null)
-        #administrationRoute: administrationRoute,
-      if (ester != $none) #ester: ester,
-      if (supplyItemId != $none) #supplyItemId: supplyItemId,
-      if (notes != $none) #notes: notes,
-      if (updatedAt != $none) #updatedAt: updatedAt,
-      if (isDeleted != null) #isDeleted: isDeleted,
-    }),
-  );
+  }) =>
+      $apply(
+        FieldCopyWithData({
+          if (id != $none) #id: id,
+          if (scheduledDateTime != null) #scheduledDateTime: scheduledDateTime,
+          if (dose != null) #dose: dose,
+          if (takenDateTime != $none) #takenDateTime: takenDateTime,
+          if (takenTimeZone != $none) #takenTimeZone: takenTimeZone,
+          if (scheduleId != $none) #scheduleId: scheduleId,
+          if (side != $none) #side: side,
+          if (molecule != null) #molecule: molecule,
+          if (administrationRoute != null)
+            #administrationRoute: administrationRoute,
+          if (ester != $none) #ester: ester,
+          if (supplyItemId != $none) #supplyItemId: supplyItemId,
+          if (notes != $none) #notes: notes,
+          if (updatedAt != $none) #updatedAt: updatedAt,
+          if (isDeleted != null) #isDeleted: isDeleted,
+        }),
+      );
   @override
   MedicationIntake $make(CopyWithData data) => MedicationIntake(
-    id: data.get(#id, or: $value.id),
-    scheduledDateTime: data.get(
-      #scheduledDateTime,
-      or: $value.scheduledDateTime,
-    ),
-    dose: data.get(#dose, or: $value.dose),
-    takenDateTime: data.get(#takenDateTime, or: $value.takenDateTime),
-    takenTimeZone: data.get(#takenTimeZone, or: $value.takenTimeZone),
-    scheduleId: data.get(#scheduleId, or: $value.scheduleId),
-    side: data.get(#side, or: $value.side),
-    molecule: data.get(#molecule, or: $value.molecule),
-    administrationRoute: data.get(
-      #administrationRoute,
-      or: $value.administrationRoute,
-    ),
-    ester: data.get(#ester, or: $value.ester),
-    supplyItemId: data.get(#supplyItemId, or: $value.supplyItemId),
-    notes: data.get(#notes, or: $value.notes),
-    updatedAt: data.get(#updatedAt, or: $value.updatedAt),
-    isDeleted: data.get(#isDeleted, or: $value.isDeleted),
-  );
+        id: data.get(#id, or: $value.id),
+        scheduledDateTime: data.get(
+          #scheduledDateTime,
+          or: $value.scheduledDateTime,
+        ),
+        dose: data.get(#dose, or: $value.dose),
+        takenDateTime: data.get(#takenDateTime, or: $value.takenDateTime),
+        takenTimeZone: data.get(#takenTimeZone, or: $value.takenTimeZone),
+        scheduleId: data.get(#scheduleId, or: $value.scheduleId),
+        side: data.get(#side, or: $value.side),
+        molecule: data.get(#molecule, or: $value.molecule),
+        administrationRoute: data.get(
+          #administrationRoute,
+          or: $value.administrationRoute,
+        ),
+        ester: data.get(#ester, or: $value.ester),
+        supplyItemId: data.get(#supplyItemId, or: $value.supplyItemId),
+        notes: data.get(#notes, or: $value.notes),
+        updatedAt: data.get(#updatedAt, or: $value.updatedAt),
+        isDeleted: data.get(#isDeleted, or: $value.isDeleted),
+      );
 
   @override
   MedicationIntakeCopyWith<$R2, MedicationIntake, $Out2> $chain<$R2, $Out2>(
     Then<$Out2, $R2> t,
-  ) => _MedicationIntakeCopyWithImpl<$R2, $Out2>($value, $cast, t);
+  ) =>
+      _MedicationIntakeCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
-

--- a/lib/data/model/medication_intake.mapper.dart
+++ b/lib/data/model/medication_intake.mapper.dart
@@ -75,8 +75,8 @@ class MedicationIntakeMapper extends ClassMapperBase<MedicationIntake> {
   @override
   final String id = 'MedicationIntake';
 
-  static int _$id(MedicationIntake v) => v.id;
-  static const Field<MedicationIntake, int> _f$id = Field(
+  static String _$id(MedicationIntake v) => v.id;
+  static const Field<MedicationIntake, String> _f$id = Field(
     'id',
     _$id,
     opt: true,
@@ -101,8 +101,8 @@ class MedicationIntakeMapper extends ClassMapperBase<MedicationIntake> {
     _$takenTimeZone,
     opt: true,
   );
-  static int? _$scheduleId(MedicationIntake v) => v.scheduleId;
-  static const Field<MedicationIntake, int> _f$scheduleId = Field(
+  static String? _$scheduleId(MedicationIntake v) => v.scheduleId;
+  static const Field<MedicationIntake, String> _f$scheduleId = Field(
     'scheduleId',
     _$scheduleId,
     opt: true,
@@ -122,7 +122,7 @@ class MedicationIntakeMapper extends ClassMapperBase<MedicationIntake> {
   static AdministrationRoute _$administrationRoute(MedicationIntake v) =>
       v.administrationRoute;
   static const Field<MedicationIntake, AdministrationRoute>
-      _f$administrationRoute = Field(
+  _f$administrationRoute = Field(
     'administrationRoute',
     _$administrationRoute,
     key: r'administrationRouteName',
@@ -134,8 +134,8 @@ class MedicationIntakeMapper extends ClassMapperBase<MedicationIntake> {
     key: r'esterName',
     opt: true,
   );
-  static int? _$supplyItemId(MedicationIntake v) => v.supplyItemId;
-  static const Field<MedicationIntake, int> _f$supplyItemId = Field(
+  static String? _$supplyItemId(MedicationIntake v) => v.supplyItemId;
+  static const Field<MedicationIntake, String> _f$supplyItemId = Field(
     'supplyItemId',
     _$supplyItemId,
     opt: true,
@@ -145,6 +145,20 @@ class MedicationIntakeMapper extends ClassMapperBase<MedicationIntake> {
     'notes',
     _$notes,
     opt: true,
+  );
+  static int _$updatedAt(MedicationIntake v) => v.updatedAt;
+  static const Field<MedicationIntake, int> _f$updatedAt = Field(
+    'updatedAt',
+    _$updatedAt,
+    opt: true,
+  );
+  static bool _$isDeleted(MedicationIntake v) => v.isDeleted;
+  static const Field<MedicationIntake, bool> _f$isDeleted = Field(
+    'isDeleted',
+    _$isDeleted,
+    opt: true,
+    def: false,
+    hook: BoolIntHook(),
   );
 
   @override
@@ -161,6 +175,8 @@ class MedicationIntakeMapper extends ClassMapperBase<MedicationIntake> {
     #ester: _f$ester,
     #supplyItemId: _f$supplyItemId,
     #notes: _f$notes,
+    #updatedAt: _f$updatedAt,
+    #isDeleted: _f$isDeleted,
   };
 
   static MedicationIntake _instantiate(DecodingData data) {
@@ -177,6 +193,8 @@ class MedicationIntakeMapper extends ClassMapperBase<MedicationIntake> {
       ester: data.dec(_f$ester),
       supplyItemId: data.dec(_f$supplyItemId),
       notes: data.dec(_f$notes),
+      updatedAt: data.dec(_f$updatedAt),
+      isDeleted: data.dec(_f$isDeleted),
     );
   }
 
@@ -204,12 +222,12 @@ mixin MedicationIntakeMappable {
   }
 
   MedicationIntakeCopyWith<MedicationIntake, MedicationIntake, MedicationIntake>
-      get copyWith =>
-          _MedicationIntakeCopyWithImpl<MedicationIntake, MedicationIntake>(
-            this as MedicationIntake,
-            $identity,
-            $identity,
-          );
+  get copyWith =>
+      _MedicationIntakeCopyWithImpl<MedicationIntake, MedicationIntake>(
+        this as MedicationIntake,
+        $identity,
+        $identity,
+      );
   @override
   String toString() {
     return MedicationIntakeMapper.ensureInitialized().stringifyValue(
@@ -236,25 +254,27 @@ mixin MedicationIntakeMappable {
 extension MedicationIntakeValueCopy<$R, $Out>
     on ObjectCopyWith<$R, MedicationIntake, $Out> {
   MedicationIntakeCopyWith<$R, MedicationIntake, $Out>
-      get $asMedicationIntake => $base
-          .as((v, t, t2) => _MedicationIntakeCopyWithImpl<$R, $Out>(v, t, t2));
+  get $asMedicationIntake =>
+      $base.as((v, t, t2) => _MedicationIntakeCopyWithImpl<$R, $Out>(v, t, t2));
 }
 
 abstract class MedicationIntakeCopyWith<$R, $In extends MedicationIntake, $Out>
     implements ClassCopyWith<$R, $In, $Out> {
   $R call({
-    int? id,
+    String? id,
     DateTime? scheduledDateTime,
     Decimal? dose,
     DateTime? takenDateTime,
     String? takenTimeZone,
-    int? scheduleId,
+    String? scheduleId,
     InjectionSide? side,
     Molecule? molecule,
     AdministrationRoute? administrationRoute,
     Ester? ester,
-    int? supplyItemId,
+    String? supplyItemId,
     String? notes,
+    int? updatedAt,
+    bool? isDeleted,
   });
   MedicationIntakeCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
     Then<$Out2, $R2> t,
@@ -283,49 +303,54 @@ class _MedicationIntakeCopyWithImpl<$R, $Out>
     Object? ester = $none,
     Object? supplyItemId = $none,
     Object? notes = $none,
-  }) =>
-      $apply(
-        FieldCopyWithData({
-          if (id != $none) #id: id,
-          if (scheduledDateTime != null) #scheduledDateTime: scheduledDateTime,
-          if (dose != null) #dose: dose,
-          if (takenDateTime != $none) #takenDateTime: takenDateTime,
-          if (takenTimeZone != $none) #takenTimeZone: takenTimeZone,
-          if (scheduleId != $none) #scheduleId: scheduleId,
-          if (side != $none) #side: side,
-          if (molecule != null) #molecule: molecule,
-          if (administrationRoute != null)
-            #administrationRoute: administrationRoute,
-          if (ester != $none) #ester: ester,
-          if (supplyItemId != $none) #supplyItemId: supplyItemId,
-          if (notes != $none) #notes: notes,
-        }),
-      );
+    Object? updatedAt = $none,
+    bool? isDeleted,
+  }) => $apply(
+    FieldCopyWithData({
+      if (id != $none) #id: id,
+      if (scheduledDateTime != null) #scheduledDateTime: scheduledDateTime,
+      if (dose != null) #dose: dose,
+      if (takenDateTime != $none) #takenDateTime: takenDateTime,
+      if (takenTimeZone != $none) #takenTimeZone: takenTimeZone,
+      if (scheduleId != $none) #scheduleId: scheduleId,
+      if (side != $none) #side: side,
+      if (molecule != null) #molecule: molecule,
+      if (administrationRoute != null)
+        #administrationRoute: administrationRoute,
+      if (ester != $none) #ester: ester,
+      if (supplyItemId != $none) #supplyItemId: supplyItemId,
+      if (notes != $none) #notes: notes,
+      if (updatedAt != $none) #updatedAt: updatedAt,
+      if (isDeleted != null) #isDeleted: isDeleted,
+    }),
+  );
   @override
   MedicationIntake $make(CopyWithData data) => MedicationIntake(
-        id: data.get(#id, or: $value.id),
-        scheduledDateTime: data.get(
-          #scheduledDateTime,
-          or: $value.scheduledDateTime,
-        ),
-        dose: data.get(#dose, or: $value.dose),
-        takenDateTime: data.get(#takenDateTime, or: $value.takenDateTime),
-        takenTimeZone: data.get(#takenTimeZone, or: $value.takenTimeZone),
-        scheduleId: data.get(#scheduleId, or: $value.scheduleId),
-        side: data.get(#side, or: $value.side),
-        molecule: data.get(#molecule, or: $value.molecule),
-        administrationRoute: data.get(
-          #administrationRoute,
-          or: $value.administrationRoute,
-        ),
-        ester: data.get(#ester, or: $value.ester),
-        supplyItemId: data.get(#supplyItemId, or: $value.supplyItemId),
-        notes: data.get(#notes, or: $value.notes),
-      );
+    id: data.get(#id, or: $value.id),
+    scheduledDateTime: data.get(
+      #scheduledDateTime,
+      or: $value.scheduledDateTime,
+    ),
+    dose: data.get(#dose, or: $value.dose),
+    takenDateTime: data.get(#takenDateTime, or: $value.takenDateTime),
+    takenTimeZone: data.get(#takenTimeZone, or: $value.takenTimeZone),
+    scheduleId: data.get(#scheduleId, or: $value.scheduleId),
+    side: data.get(#side, or: $value.side),
+    molecule: data.get(#molecule, or: $value.molecule),
+    administrationRoute: data.get(
+      #administrationRoute,
+      or: $value.administrationRoute,
+    ),
+    ester: data.get(#ester, or: $value.ester),
+    supplyItemId: data.get(#supplyItemId, or: $value.supplyItemId),
+    notes: data.get(#notes, or: $value.notes),
+    updatedAt: data.get(#updatedAt, or: $value.updatedAt),
+    isDeleted: data.get(#isDeleted, or: $value.isDeleted),
+  );
 
   @override
   MedicationIntakeCopyWith<$R2, MedicationIntake, $Out2> $chain<$R2, $Out2>(
     Then<$Out2, $R2> t,
-  ) =>
-      _MedicationIntakeCopyWithImpl<$R2, $Out2>($value, $cast, t);
+  ) => _MedicationIntakeCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
+

--- a/lib/data/model/medication_schedule.dart
+++ b/lib/data/model/medication_schedule.dart
@@ -9,9 +9,10 @@ import 'package:mona/data/model/molecule.dart';
 import 'package:mona/l10n/app_localizations.dart';
 import 'package:mona/util/string_parsing.dart';
 import 'package:mona/util/validators.dart';
+import 'package:uuid/uuid.dart';
 
 class MedicationSchedule {
-  final int id;
+  final String id;
   final String name;
   final Decimal dose;
   final int intervalDays;
@@ -20,9 +21,11 @@ class MedicationSchedule {
   final AdministrationRoute administrationRoute;
   final Ester? ester;
   List<TimeOfDay> notificationTimes;
+  final int updatedAt;
+  final bool isDeleted;
 
   MedicationSchedule({
-    int? id,
+    String? id,
     required this.name,
     required this.dose,
     required this.intervalDays,
@@ -31,12 +34,15 @@ class MedicationSchedule {
     required this.administrationRoute,
     this.ester,
     required this.notificationTimes,
-  })  : id = id ?? DateTime.now().millisecondsSinceEpoch,
-        startDate = startDate ?? Date.today();
+    int? updatedAt,
+    this.isDeleted = false,
+  })  : id = id ?? const Uuid().v4(),
+        startDate = startDate ?? Date.today(),
+        updatedAt = updatedAt ?? DateTime.now().millisecondsSinceEpoch;
 
   factory MedicationSchedule.fromMap(Map<String, Object?> map) {
     return MedicationSchedule(
-      id: map['id'] as int,
+      id: map['id'] as String,
       name: map['name'] as String,
       dose: (map['dose'] as String).toDecimal,
       intervalDays: map['intervalDays'] as int,
@@ -46,6 +52,8 @@ class MedicationSchedule {
           map['administrationRouteName'] as String),
       ester: Ester.fromName(map['esterName'] as String?),
       notificationTimes: _decodeTimes(map['notificationTimes'] as String),
+      updatedAt: map['updatedAt'] as int?,
+      isDeleted: (map['isDeleted'] as int?) == 1,
     );
   }
 
@@ -136,11 +144,13 @@ class MedicationSchedule {
       'administrationRouteName': administrationRoute.name,
       'esterName': ester?.name,
       'notificationTimes': _encodeTimes(notificationTimes),
+      'updatedAt': updatedAt,
+      'isDeleted': isDeleted ? 1 : 0,
     };
   }
 
   MedicationSchedule copyWith({
-    int? id,
+    String? id,
     String? name,
     Decimal? dose,
     int? intervalDays,
@@ -150,6 +160,8 @@ class MedicationSchedule {
     Ester? ester,
     bool clearEster = false,
     List<TimeOfDay>? notificationTimes,
+    int? updatedAt,
+    bool? isDeleted,
   }) {
     return MedicationSchedule(
       id: id ?? this.id,
@@ -161,6 +173,8 @@ class MedicationSchedule {
       administrationRoute: administrationRoute ?? this.administrationRoute,
       ester: clearEster ? null : (ester ?? this.ester),
       notificationTimes: notificationTimes ?? this.notificationTimes,
+      updatedAt: updatedAt ?? this.updatedAt,
+      isDeleted: isDeleted ?? this.isDeleted,
     );
   }
 

--- a/lib/data/model/medication_supply_item.dart
+++ b/lib/data/model/medication_supply_item.dart
@@ -8,10 +8,11 @@ import 'package:mona/data/model/supply_item.dart';
 import 'package:mona/l10n/app_localizations.dart';
 import 'package:mona/util/string_parsing.dart';
 import 'package:mona/util/validators.dart';
+import 'package:uuid/uuid.dart';
 
 class MedicationSupplyItem implements SupplyItem {
   @override
-  final int id;
+  final String id;
   @override
   final String name;
   final Decimal totalDose;
@@ -20,9 +21,13 @@ class MedicationSupplyItem implements SupplyItem {
   final Molecule molecule;
   final AdministrationRoute administrationRoute;
   final Ester? ester;
+  @override
+  final int updatedAt;
+  @override
+  final bool isDeleted;
 
   MedicationSupplyItem({
-    int? id,
+    String? id,
     required this.name,
     required this.totalDose,
     required this.concentration,
@@ -30,12 +35,15 @@ class MedicationSupplyItem implements SupplyItem {
     required this.molecule,
     required this.administrationRoute,
     this.ester,
+    int? updatedAt,
+    this.isDeleted = false,
   })  : usedDose = usedDose ?? Decimal.zero,
-        id = id ?? DateTime.now().millisecondsSinceEpoch;
+        id = id ?? const Uuid().v4(),
+        updatedAt = updatedAt ?? DateTime.now().millisecondsSinceEpoch;
 
   factory MedicationSupplyItem.fromMap(Map<String, Object?> map) {
     return MedicationSupplyItem(
-      id: map['id'] as int?,
+      id: map['id'] as String?,
       name: map['name'] as String,
       totalDose: (map['totalDose'] as String).toDecimal,
       usedDose: (map['usedDose'] as String).toDecimal,
@@ -44,6 +52,8 @@ class MedicationSupplyItem implements SupplyItem {
       administrationRoute: AdministrationRoute.fromName(
           map['administrationRouteName'] as String),
       ester: Ester.fromName(map['esterName'] as String?),
+      updatedAt: map['updatedAt'] as int?,
+      isDeleted: (map['isDeleted'] as int?) == 1,
     );
   }
 
@@ -80,6 +90,8 @@ class MedicationSupplyItem implements SupplyItem {
       'administrationRouteName': administrationRoute.name,
       'esterName': ester?.name,
       'type': SupplyType.medication.name,
+      'updatedAt': updatedAt,
+      'isDeleted': isDeleted ? 1 : 0,
     };
   }
 
@@ -90,7 +102,7 @@ class MedicationSupplyItem implements SupplyItem {
   Decimal getDose(Decimal amount) => amount * concentration;
 
   MedicationSupplyItem copyWith({
-    int? id,
+    String? id,
     String? name,
     Decimal? totalDose,
     Decimal? usedDose,
@@ -99,6 +111,8 @@ class MedicationSupplyItem implements SupplyItem {
     AdministrationRoute? administrationRoute,
     Ester? ester,
     bool clearEster = false,
+    int? updatedAt,
+    bool? isDeleted,
   }) {
     return MedicationSupplyItem(
       id: id ?? this.id,
@@ -109,6 +123,8 @@ class MedicationSupplyItem implements SupplyItem {
       molecule: molecule ?? this.molecule,
       administrationRoute: administrationRoute ?? this.administrationRoute,
       ester: clearEster ? null : (ester ?? this.ester),
+      updatedAt: updatedAt ?? this.updatedAt,
+      isDeleted: isDeleted ?? this.isDeleted,
     );
   }
 

--- a/lib/data/model/supply_item.dart
+++ b/lib/data/model/supply_item.dart
@@ -9,8 +9,10 @@ enum SupplyType {
 }
 
 abstract class SupplyItem {
-  int get id;
+  String get id;
   String get name;
+  int get updatedAt;
+  bool get isDeleted;
 
   factory SupplyItem.fromMap(Map<String, Object?> map) {
     final SupplyType type = SupplyType.values.byName(map['type'] as String);

--- a/lib/data/providers/blood_test_provider.dart
+++ b/lib/data/providers/blood_test_provider.dart
@@ -18,7 +18,7 @@ class BloodTestProvider extends ChangeNotifier {
   bool get isLoading => _isLoading;
   List<BloodTest> get bloodtestsSortedDesc => _bloodtestsSortedDesc;
 
-  Future<void> deleteBloodTestFromId(int id) async {
+  Future<void> deleteBloodTestFromId(String id) async {
     await repository.delete(id);
     await _fetchBloodTests();
   }

--- a/lib/data/providers/medication_intake_provider.dart
+++ b/lib/data/providers/medication_intake_provider.dart
@@ -55,7 +55,7 @@ class MedicationIntakeProvider extends ChangeNotifier {
       ..sort((a, b) => b.takenDateTime!.compareTo(a.takenDateTime!));
   }
 
-  List<MedicationIntake> getTakenIntakesForSchedule(int scheduleId) =>
+  List<MedicationIntake> getTakenIntakesForSchedule(String scheduleId) =>
       takenIntakes.where((intake) => intake.scheduleId == scheduleId).toList();
 
   Future<void> fetchIntakes() async {
@@ -64,7 +64,7 @@ class MedicationIntakeProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> deleteIntakeFromId(int id) async {
+  Future<void> deleteIntakeFromId(String id) async {
     await repository.delete(id);
     await fetchIntakes();
   }
@@ -118,7 +118,7 @@ class MedicationIntakeProvider extends ChangeNotifier {
     return getLastIntakeLocalDateFromList(graphIntakes);
   }
 
-  Date? getLastIntakeLocalDateForSchedule(int scheduleId) {
+  Date? getLastIntakeLocalDateForSchedule(String scheduleId) {
     final scheduleIntakes = getTakenIntakesForSchedule(scheduleId);
     return getLastIntakeLocalDateFromList(scheduleIntakes);
   }

--- a/lib/data/providers/medication_schedule_provider.dart
+++ b/lib/data/providers/medication_schedule_provider.dart
@@ -10,7 +10,7 @@ class MedicationScheduleProvider extends ChangeNotifier {
   List<MedicationSchedule> get schedules => _schedules;
   bool get isLoading => _isLoading;
 
-  MedicationSchedule? getScheduleById(int id) {
+  MedicationSchedule? getScheduleById(String id) {
     try {
       return _schedules.firstWhere((schedule) => schedule.id == id);
     } catch (e) {
@@ -34,7 +34,7 @@ class MedicationScheduleProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> deleteScheduleFromId(int id) async {
+  Future<void> deleteScheduleFromId(String id) async {
     await repository.delete(id);
     await fetchSchedules();
   }

--- a/lib/data/providers/supply_item_provider.dart
+++ b/lib/data/providers/supply_item_provider.dart
@@ -33,7 +33,7 @@ class SupplyItemProvider extends ChangeNotifier {
           (a, b) => a.getRatio().compareTo(b.getRatio()),
         );
 
-  SupplyItem? getItemById(int? id) {
+  SupplyItem? getItemById(String? id) {
     try {
       return items.firstWhere((item) => item.id == id);
     } catch (e) {

--- a/lib/services/db/app_database.dart
+++ b/lib/services/db/app_database.dart
@@ -8,10 +8,11 @@ import 'package:mona/services/db/upgrade/v4.dart';
 import 'package:mona/services/db/upgrade/v5.dart';
 import 'package:mona/services/db/upgrade/v6.dart';
 import 'package:mona/services/db/upgrade/v7.dart';
+import 'package:mona/services/db/upgrade/v8.dart';
 import 'package:path/path.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
-const int currentDatabaseVersion = 7;
+const int currentDatabaseVersion = 8;
 
 final Map<int, DbUpgrade> _upgrades = {
   2: DbUpgradeV2(),
@@ -20,6 +21,7 @@ final Map<int, DbUpgrade> _upgrades = {
   5: DbUpgradeV5(),
   6: DbUpgradeV6(),
   7: DbUpgradeV7(),
+  8: DbUpgradeV8(),
 };
 
 class AppDatabase {

--- a/lib/services/db/db_tables.dart
+++ b/lib/services/db/db_tables.dart
@@ -1,6 +1,6 @@
-const String createSupplyItemsTable = '''
+const String createSupplyItemsTable = '''int
     CREATE TABLE supply_items(
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      id TEXT PRIMARY KEY NOT NULL,
       type TEXT NOT NULL,
       name TEXT NOT NULL,
       totalDose TEXT,
@@ -9,31 +9,35 @@ const String createSupplyItemsTable = '''
       moleculeJson TEXT,
       administrationRouteName TEXT,
       esterName TEXT,
-      amount INTEGER
+      amount INTEGER,
+      updatedAt INTEGER NOT NULL,
+      isDeleted BOOLEAN NOT NULL DEFAULT 0
     )
     ''';
 
 const String createMedicationIntakesTable = '''
     CREATE TABLE medication_intakes(
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      id TEXT PRIMARY KEY NOT NULL,
       scheduledDateTime TEXT NOT NULL,
       takenDateTime TEXT,
       takenTimeZone TEXT,
       dose TEXT NOT NULL,
-      scheduleId INTEGER,
+      scheduleId TEXT,
       side TEXT,
       moleculeJson TEXT NOT NULL,
       administrationRouteName TEXT NOT NULL,
       esterName TEXT,
-      supplyItemId INTEGER,
+      supplyItemId TEXT,
       notes TEXT,
+      updatedAt INTEGER NOT NULL,
+      isDeleted BOOLEAN NOT NULL DEFAULT 0,
       FOREIGN KEY (supplyItemId) REFERENCES supply_items(id) ON DELETE SET NULL
     )
-    '''; // TODO use foreign key for scheduleId
+    ''';
 
 const String createMedicationSchedulesTable = '''
     CREATE TABLE medication_schedules(
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      id TEXT PRIMARY KEY NOT NULL,
       name TEXT NOT NULL,
       dose TEXT NOT NULL,
       intervalDays INTEGER NOT NULL,
@@ -41,18 +45,22 @@ const String createMedicationSchedulesTable = '''
       moleculeJson TEXT NOT NULL,
       administrationRouteName TEXT NOT NULL,
       esterName TEXT,
-      notificationTimes TEXT NOT NULL
+      notificationTimes TEXT NOT NULL,
+      updatedAt INTEGER NOT NULL,
+      isDeleted BOOLEAN NOT NULL DEFAULT 0
     )
     ''';
 
 const String createBloodTestsTable = '''
     CREATE TABLE blood_tests(
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      id TEXT PRIMARY KEY NOT NULL,
       dateTime TEXT NOT NULL,
       timeZone TEXT NOT NULL,
       estradiolLevels TEXT,
       testosteroneLevels TEXT,
       estradiolUnit TEXT,
-      testosteroneUnit TEXT
+      testosteroneUnit TEXT,
+      updatedAt INTEGER NOT NULL,
+      isDeleted BOOLEAN NOT NULL DEFAULT 0
     )
     ''';

--- a/lib/services/db/db_tables.dart
+++ b/lib/services/db/db_tables.dart
@@ -1,4 +1,4 @@
-const String createSupplyItemsTable = '''int
+const String createSupplyItemsTable = '''
     CREATE TABLE supply_items(
       id TEXT PRIMARY KEY NOT NULL,
       type TEXT NOT NULL,

--- a/lib/services/db/historical_schemas.dart
+++ b/lib/services/db/historical_schemas.dart
@@ -87,6 +87,36 @@ const String _supplyItemsV6 = '''
     )
     ''';
 
+const String _medicationIntakesV7 = '''
+    CREATE TABLE medication_intakes(
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      scheduledDateTime TEXT NOT NULL,
+      takenDateTime TEXT,
+      takenTimeZone TEXT,
+      dose TEXT NOT NULL,
+      scheduleId INTEGER,
+      side TEXT,
+      moleculeJson TEXT NOT NULL,
+      administrationRouteName TEXT NOT NULL,
+      esterName TEXT,
+      supplyItemId INTEGER,
+      notes TEXT,
+      FOREIGN KEY (supplyItemId) REFERENCES supply_items(id) ON DELETE SET NULL
+    )
+    ''';
+
+const String _bloodTestsV7 = '''
+    CREATE TABLE blood_tests(
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      dateTime TEXT NOT NULL,
+      timeZone TEXT NOT NULL,
+      estradiolLevels TEXT,
+      testosteroneLevels TEXT,
+      estradiolUnit TEXT,
+      testosteroneUnit TEXT
+    )
+    ''';
+
 const Map<int, List<String>> _historicalSchemas = {
   4: [
     _supplyItemsV4,
@@ -107,6 +137,12 @@ const Map<int, List<String>> _historicalSchemas = {
     _bloodTestsV4,
   ],
   7: [
+    _supplyItemsV6,
+    _medicationIntakesV7,
+    _medicationSchedulesV4,
+    _bloodTestsV7,
+  ],
+  8: [
     createSupplyItemsTable,
     createMedicationIntakesTable,
     createMedicationSchedulesTable,

--- a/lib/services/db/upgrade/v8.dart
+++ b/lib/services/db/upgrade/v8.dart
@@ -9,8 +9,8 @@ class DbUpgradeV8 implements DbUpgrade {
     const uuid = Uuid();
     final now = DateTime.now().millisecondsSinceEpoch;
 
-    Map<int, String> supplyItemMap = {};
-    Map<int, String> scheduleMap = {};
+    Map<dynamic, String> supplyItemMap = {};
+    Map<dynamic, String> scheduleMap = {};
 
     final oldSupplies = await db.query('supply_items');
     final oldSchedules = await db.query('medication_schedules');
@@ -29,7 +29,7 @@ class DbUpgradeV8 implements DbUpgrade {
 
     for (var row in oldSupplies) {
       final newId = uuid.v4();
-      supplyItemMap[row['id'] as int] = newId;
+      supplyItemMap[row['id']] = newId;
 
       var newRow = Map<String, dynamic>.from(row);
       newRow['id'] = newId;
@@ -40,7 +40,7 @@ class DbUpgradeV8 implements DbUpgrade {
 
     for (var row in oldSchedules) {
       final newId = uuid.v4();
-      scheduleMap[row['id'] as int] = newId;
+      scheduleMap[row['id']] = newId;
 
       var newRow = Map<String, dynamic>.from(row);
       newRow['id'] = newId;
@@ -56,10 +56,10 @@ class DbUpgradeV8 implements DbUpgrade {
       newRow['isDeleted'] = 0;
 
       if (row['scheduleId'] != null) {
-        newRow['scheduleId'] = scheduleMap[row['scheduleId'] as int];
+        newRow['scheduleId'] = scheduleMap[row['scheduleId']];
       }
       if (row['supplyItemId'] != null) {
-        newRow['supplyItemId'] = supplyItemMap[row['supplyItemId'] as int];
+        newRow['supplyItemId'] = supplyItemMap[row['supplyItemId']];
       }
       await db.insert('medication_intakes_new', newRow);
     }

--- a/lib/services/db/upgrade/v8.dart
+++ b/lib/services/db/upgrade/v8.dart
@@ -1,0 +1,87 @@
+import 'package:mona/services/db/db_tables.dart';
+import 'package:mona/services/db/upgrade/db_upgrade.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:uuid/uuid.dart';
+
+class DbUpgradeV8 implements DbUpgrade {
+  @override
+  Future<void> upgrade(Database db, int oldVersion, int newVersion) async {
+    const uuid = Uuid();
+    final now = DateTime.now().millisecondsSinceEpoch;
+
+    Map<int, String> supplyItemMap = {};
+    Map<int, String> scheduleMap = {};
+
+    final oldSupplies = await db.query('supply_items');
+    final oldSchedules = await db.query('medication_schedules');
+    final oldIntakes = await db.query('medication_intakes');
+    final oldTests = await db.query('blood_tests');
+
+    await db.execute(
+        createSupplyItemsTable.replaceAll('supply_items', 'supply_items_new'));
+    await db.execute(createMedicationSchedulesTable.replaceAll(
+        'medication_schedules', 'medication_schedules_new'));
+    await db.execute(createMedicationIntakesTable
+        .replaceAll('medication_intakes', 'medication_intakes_new')
+        .replaceAll('supply_items(id)', 'supply_items_new(id)'));
+    await db.execute(
+        createBloodTestsTable.replaceAll('blood_tests', 'blood_tests_new'));
+
+    for (var row in oldSupplies) {
+      final newId = uuid.v4();
+      supplyItemMap[row['id'] as int] = newId;
+
+      var newRow = Map<String, dynamic>.from(row);
+      newRow['id'] = newId;
+      newRow['updatedAt'] = now;
+      newRow['isDeleted'] = 0;
+      await db.insert('supply_items_new', newRow);
+    }
+
+    for (var row in oldSchedules) {
+      final newId = uuid.v4();
+      scheduleMap[row['id'] as int] = newId;
+
+      var newRow = Map<String, dynamic>.from(row);
+      newRow['id'] = newId;
+      newRow['updatedAt'] = now;
+      newRow['isDeleted'] = 0;
+      await db.insert('medication_schedules_new', newRow);
+    }
+
+    for (var row in oldIntakes) {
+      var newRow = Map<String, dynamic>.from(row);
+      newRow['id'] = uuid.v4();
+      newRow['updatedAt'] = now;
+      newRow['isDeleted'] = 0;
+
+      if (row['scheduleId'] != null) {
+        newRow['scheduleId'] = scheduleMap[row['scheduleId'] as int];
+      }
+      if (row['supplyItemId'] != null) {
+        newRow['supplyItemId'] = supplyItemMap[row['supplyItemId'] as int];
+      }
+      await db.insert('medication_intakes_new', newRow);
+    }
+
+    for (var row in oldTests) {
+      var newRow = Map<String, dynamic>.from(row);
+      newRow['id'] = uuid.v4();
+      newRow['updatedAt'] = now;
+      newRow['isDeleted'] = 0;
+      await db.insert('blood_tests_new', newRow);
+    }
+
+    await db.execute('DROP TABLE supply_items');
+    await db.execute('DROP TABLE medication_schedules');
+    await db.execute('DROP TABLE medication_intakes');
+    await db.execute('DROP TABLE blood_tests');
+
+    await db.execute('ALTER TABLE supply_items_new RENAME TO supply_items');
+    await db.execute(
+        'ALTER TABLE medication_schedules_new RENAME TO medication_schedules');
+    await db.execute(
+        'ALTER TABLE medication_intakes_new RENAME TO medication_intakes');
+    await db.execute('ALTER TABLE blood_tests_new RENAME TO blood_tests');
+  }
+}

--- a/lib/services/repository.dart
+++ b/lib/services/repository.dart
@@ -30,7 +30,7 @@ class Repository<T> {
     return result.map(fromMap).toList();
   }
 
-  Future<void> update(T element, int id) async {
+  Future<void> update(T element, dynamic id) async {
     final db = await _dbFuture;
     await db.update(
       tableName,
@@ -40,7 +40,7 @@ class Repository<T> {
     );
   }
 
-  Future<void> delete(int id) async {
+  Future<void> delete(dynamic id) async {
     final db = await _dbFuture;
     await db.delete(
       tableName,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1148,7 +1148,7 @@ packages:
     source: hosted
     version: "3.1.5"
   uuid:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: uuid
       sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -67,6 +67,7 @@ dependencies:
   file_picker: ^8.0.0
   share_plus: ^10.0.0
   dart_mappable: ^4.8.0
+  uuid: ^4.5.3
 
 dev_dependencies:
   flutter_test:

--- a/test/controllers/medication_intake_manager_test.dart
+++ b/test/controllers/medication_intake_manager_test.dart
@@ -109,8 +109,8 @@ void main() {
         final scheduledDate = DateTime(2025, 9, 14, 10, 30);
         final takenDate = DateTime.utc(2025, 9, 14, 12, 0);
         final notes = 'yummy';
-        final supplyItemId = 99;
-        final scheduleId = 42;
+        final supplyItemId = '99';
+        final scheduleId = '42';
 
         setUp(() async {
           // Arrange
@@ -240,7 +240,7 @@ void main() {
       group('GenericSupply', () {
         late MedicationIntake addedIntake;
         late GenericSupply updatedSupplyItem;
-        final supplyItem = _buildGenericSupply(id: 7, amount: 5);
+        final supplyItem = _buildGenericSupply(id: '7', amount: 5);
 
         setUp(() async {
           // Arrange
@@ -406,7 +406,7 @@ void main() {
 
     group('deleteIntake', () {
       group('when supply lookup returns null', () {
-        final intake = _buildIntake(supplyItemId: 10);
+        final intake = _buildIntake(supplyItemId: '10');
 
         setUp(() async {
           // Act
@@ -426,7 +426,7 @@ void main() {
 
       group('GenericSupply', () {
         late GenericSupply updatedSupplyItem;
-        final supplyItem = _buildGenericSupply(id: 7, amount: 5);
+        final supplyItem = _buildGenericSupply(id: '7', amount: 5);
         final intake = _buildIntake(supplyItemId: supplyItem.id);
 
         setUp(() async {
@@ -551,12 +551,12 @@ void main() {
       test('returns right when last side is left', () {
         // Arrange
         final firstIntake = MedicationIntake(
-          id: 1,
+          id: '1',
           scheduledDateTime: DateTime(2025, 9, 14, 10, 30),
           dose: Decimal.parse('2.5'),
           takenDateTime: DateTime.utc(2025, 9, 14, 12, 0),
           takenTimeZone: 'Etc/UTC',
-          scheduleId: 42,
+          scheduleId: '42',
           side: InjectionSide.left,
           molecule: KnownMolecules.estradiol,
           administrationRoute: AdministrationRoute.gel,
@@ -574,12 +574,12 @@ void main() {
       test('returns left when last side is right', () {
         // Arrange
         final lastIntake = MedicationIntake(
-          id: 2,
+          id: '2',
           scheduledDateTime: DateTime(2025, 9, 15, 10, 30),
           dose: Decimal.parse('2.5'),
           takenDateTime: DateTime.utc(2025, 9, 15, 12, 0),
           takenTimeZone: 'Etc/UTC',
-          scheduleId: 42,
+          scheduleId: '42',
           side: InjectionSide.right,
           molecule: KnownMolecules.estradiol,
           administrationRoute: AdministrationRoute.gel,
@@ -603,12 +603,12 @@ void main() {
       test('returns left when last intake side is null', () {
         // Arrange
         final intake = MedicationIntake(
-          id: 3,
+          id: '3',
           scheduledDateTime: DateTime(2025, 9, 16, 10, 30),
           dose: Decimal.parse('2.5'),
           takenDateTime: DateTime.utc(2025, 9, 16, 12, 0),
           takenTimeZone: 'Etc/UTC',
-          scheduleId: 42,
+          scheduleId: '42',
           side: null,
           molecule: KnownMolecules.estradiol,
           administrationRoute: AdministrationRoute.gel,
@@ -624,7 +624,7 @@ void main() {
 }
 
 MedicationSchedule _buildSchedule({
-  int? id,
+  String? id,
   Decimal? dose,
   AdministrationRoute administrationRoute = AdministrationRoute.oral,
   Ester? ester,
@@ -642,7 +642,7 @@ MedicationSchedule _buildSchedule({
 }
 
 MedicationSupplyItem _buildMedicationSupplyItem({
-  int id = 10,
+  String id = '10',
   Decimal? totalDose,
   Decimal? usedDose,
   Decimal? concentration,
@@ -662,7 +662,7 @@ MedicationSupplyItem _buildMedicationSupplyItem({
 }
 
 GenericSupply _buildGenericSupply({
-  int id = 7,
+  String id = '7',
   String name = 'Syringe',
   int amount = 5,
 }) {
@@ -674,9 +674,9 @@ GenericSupply _buildGenericSupply({
 }
 
 MedicationIntake _buildIntake({
-  int? id,
+  String? id,
   Decimal? dose,
-  int? supplyItemId,
+  String? supplyItemId,
 }) {
   return MedicationIntake(
     id: id,

--- a/test/controllers/medication_intake_manager_test.mocks.dart
+++ b/test/controllers/medication_intake_manager_test.mocks.dart
@@ -112,7 +112,7 @@ class MockMedicationIntakeProvider extends _i1.Mock
       ) as bool);
 
   @override
-  List<_i4.MedicationIntake> getTakenIntakesForSchedule(int? scheduleId) =>
+  List<_i4.MedicationIntake> getTakenIntakesForSchedule(String? scheduleId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getTakenIntakesForSchedule,
@@ -133,7 +133,7 @@ class MockMedicationIntakeProvider extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> deleteIntakeFromId(int? id) => (super.noSuchMethod(
+  _i5.Future<void> deleteIntakeFromId(String? id) => (super.noSuchMethod(
         Invocation.method(
           #deleteIntakeFromId,
           [id],
@@ -196,7 +196,7 @@ class MockMedicationIntakeProvider extends _i1.Mock
       ) as _i6.Date?);
 
   @override
-  _i6.Date? getLastIntakeLocalDateForSchedule(int? scheduleId) =>
+  _i6.Date? getLastIntakeLocalDateForSchedule(String? scheduleId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLastIntakeLocalDateForSchedule,

--- a/test/controllers/notification_scheduler_test.dart
+++ b/test/controllers/notification_scheduler_test.dart
@@ -144,6 +144,7 @@ void main() {
         when(mockPreferencesService.notificationsEnabled).thenReturn(false);
         when(mockMedicationScheduleProvider.schedules).thenReturn([
           MedicationSchedule(
+            id: '1',
             name: 'Test Medication',
             dose: Decimal.fromInt(10),
             intervalDays: 1,
@@ -199,7 +200,7 @@ void main() {
         NotificationService.isPlatformSupported = () => true;
         NotificationService.createPlugin = () => mockPlugin;
 
-        const scheduleId = 1001;
+        const scheduleId = '1001';
         when(mockPreferencesService.notificationsEnabled).thenReturn(true);
         when(mockMedicationScheduleProvider.schedules).thenReturn([
           MedicationSchedule(
@@ -250,7 +251,7 @@ void main() {
         NotificationService.isPlatformSupported = () => true;
         NotificationService.createPlugin = () => mockPlugin;
 
-        const scheduleId = 1002;
+        const scheduleId = '1002';
         final scheduledTime = TimeOfDay.fromDateTime(
             DateTime.now().add(const Duration(minutes: 1)));
         when(mockPreferencesService.notificationsEnabled).thenReturn(true);
@@ -314,7 +315,7 @@ void main() {
         NotificationService.isPlatformSupported = () => true;
         NotificationService.createPlugin = () => mockPlugin;
 
-        const scheduleId = 1003;
+        const scheduleId = '1003';
         final scheduledTime = TimeOfDay.fromDateTime(
             DateTime.now().subtract(const Duration(minutes: 1)));
         when(mockPreferencesService.notificationsEnabled).thenReturn(true);
@@ -383,7 +384,7 @@ void main() {
           TimeOfDay(hour: (now.hour + 2) % 24, minute: 30),
         ];
 
-        const scheduleId = 1004;
+        const scheduleId = '1004';
         when(mockPreferencesService.notificationsEnabled).thenReturn(true);
         when(mockMedicationScheduleProvider.schedules).thenReturn([
           MedicationSchedule(
@@ -442,7 +443,7 @@ void main() {
           'Skips future notification times today when intake already taken today',
           () async {
         // Arrange
-        const scheduleId = 4242;
+        const scheduleId = '4242';
         final origPlatformCheck = NotificationService.isPlatformSupported;
         final origCreate = NotificationService.createPlugin;
         NotificationService.isPlatformSupported = () => true;

--- a/test/controllers/notification_scheduler_test.mocks.dart
+++ b/test/controllers/notification_scheduler_test.mocks.dart
@@ -94,7 +94,7 @@ class MockMedicationScheduleProvider extends _i1.Mock
       ) as bool);
 
   @override
-  _i4.MedicationSchedule? getScheduleById(int? id) => (super.noSuchMethod(
+  _i4.MedicationSchedule? getScheduleById(String? id) => (super.noSuchMethod(
         Invocation.method(
           #getScheduleById,
           [id],
@@ -113,7 +113,7 @@ class MockMedicationScheduleProvider extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> deleteScheduleFromId(int? id) => (super.noSuchMethod(
+  _i5.Future<void> deleteScheduleFromId(String? id) => (super.noSuchMethod(
         Invocation.method(
           #deleteScheduleFromId,
           [id],
@@ -259,7 +259,7 @@ class MockMedicationIntakeProvider extends _i1.Mock
       ) as bool);
 
   @override
-  List<_i8.MedicationIntake> getTakenIntakesForSchedule(int? scheduleId) =>
+  List<_i8.MedicationIntake> getTakenIntakesForSchedule(String? scheduleId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getTakenIntakesForSchedule,
@@ -280,7 +280,7 @@ class MockMedicationIntakeProvider extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> deleteIntakeFromId(int? id) => (super.noSuchMethod(
+  _i5.Future<void> deleteIntakeFromId(String? id) => (super.noSuchMethod(
         Invocation.method(
           #deleteIntakeFromId,
           [id],
@@ -343,7 +343,7 @@ class MockMedicationIntakeProvider extends _i1.Mock
       ) as _i9.Date?);
 
   @override
-  _i9.Date? getLastIntakeLocalDateForSchedule(int? scheduleId) =>
+  _i9.Date? getLastIntakeLocalDateForSchedule(String? scheduleId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLastIntakeLocalDateForSchedule,

--- a/test/controllers/schedule_manager_test.dart
+++ b/test/controllers/schedule_manager_test.dart
@@ -42,7 +42,7 @@ void main() {
       final today = Date.today();
 
       todaySchedule = MedicationSchedule(
-        id: 1,
+        id: '1',
         name: 'TodayMed',
         dose: Decimal.one,
         intervalDays: 2,
@@ -51,11 +51,11 @@ void main() {
         administrationRoute: AdministrationRoute.oral,
         notificationTimes: List.empty(),
       );
-      when(mockIntakeProvider.getLastIntakeLocalDateForSchedule(1))
+      when(mockIntakeProvider.getLastIntakeLocalDateForSchedule('1'))
           .thenReturn(today.subtract(const Duration(days: 2)));
 
       todayTakenSchedule = MedicationSchedule(
-        id: 5,
+        id: '5',
         name: 'TodayMed',
         dose: Decimal.one,
         intervalDays: 2,
@@ -64,11 +64,11 @@ void main() {
         administrationRoute: AdministrationRoute.oral,
         notificationTimes: List.empty(),
       );
-      when(mockIntakeProvider.getLastIntakeLocalDateForSchedule(5))
+      when(mockIntakeProvider.getLastIntakeLocalDateForSchedule('5'))
           .thenReturn(Date.today());
 
       todayOverdueSchedule = MedicationSchedule(
-        id: 4,
+        id: '4',
         name: 'TodayLateMed',
         dose: Decimal.one,
         intervalDays: 2,
@@ -77,11 +77,11 @@ void main() {
         administrationRoute: AdministrationRoute.oral,
         notificationTimes: List.empty(),
       );
-      when(mockIntakeProvider.getLastIntakeLocalDateForSchedule(4))
+      when(mockIntakeProvider.getLastIntakeLocalDateForSchedule('4'))
           .thenReturn(today.subtract(const Duration(days: 3)));
 
       overdueSchedule = MedicationSchedule(
-        id: 2,
+        id: '2',
         name: 'OverdueMed',
         dose: Decimal.one,
         intervalDays: 2,
@@ -90,11 +90,11 @@ void main() {
         administrationRoute: AdministrationRoute.oral,
         notificationTimes: List.empty(),
       );
-      when(mockIntakeProvider.getLastIntakeLocalDateForSchedule(2))
+      when(mockIntakeProvider.getLastIntakeLocalDateForSchedule('2'))
           .thenReturn(today.subtract(const Duration(days: 4)));
 
       upcomingSchedule = MedicationSchedule(
-        id: 3,
+        id: '3',
         name: 'UpcomingMed',
         dose: Decimal.one,
         intervalDays: 2,
@@ -103,7 +103,7 @@ void main() {
         administrationRoute: AdministrationRoute.oral,
         notificationTimes: List.empty(),
       );
-      when(mockIntakeProvider.getLastIntakeLocalDateForSchedule(3))
+      when(mockIntakeProvider.getLastIntakeLocalDateForSchedule('3'))
           .thenReturn(null);
 
       when(mockScheduleProvider.schedules).thenReturn([
@@ -119,7 +119,7 @@ void main() {
       final today = Date.today();
 
       todaySchedule = MedicationSchedule(
-        id: 1,
+        id: '1',
         name: 'TodayMed',
         dose: Decimal.one,
         intervalDays: 2,
@@ -129,7 +129,7 @@ void main() {
         notificationTimes: List.empty(),
       );
 
-      when(mockIntakeProvider.getLastIntakeLocalDateForSchedule(1))
+      when(mockIntakeProvider.getLastIntakeLocalDateForSchedule('1'))
           .thenReturn(today.subtract(const Duration(days: 2)));
 
       final result = manager.getSchedulesByStatus(ScheduleStatus.today);

--- a/test/controllers/schedule_manager_test.mocks.dart
+++ b/test/controllers/schedule_manager_test.mocks.dart
@@ -79,7 +79,7 @@ class MockMedicationScheduleProvider extends _i1.Mock
       ) as bool);
 
   @override
-  _i4.MedicationSchedule? getScheduleById(int? id) => (super.noSuchMethod(
+  _i4.MedicationSchedule? getScheduleById(String? id) => (super.noSuchMethod(
         Invocation.method(
           #getScheduleById,
           [id],
@@ -98,7 +98,7 @@ class MockMedicationScheduleProvider extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> deleteScheduleFromId(int? id) => (super.noSuchMethod(
+  _i5.Future<void> deleteScheduleFromId(String? id) => (super.noSuchMethod(
         Invocation.method(
           #deleteScheduleFromId,
           [id],
@@ -244,7 +244,7 @@ class MockMedicationIntakeProvider extends _i1.Mock
       ) as bool);
 
   @override
-  List<_i8.MedicationIntake> getTakenIntakesForSchedule(int? scheduleId) =>
+  List<_i8.MedicationIntake> getTakenIntakesForSchedule(String? scheduleId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getTakenIntakesForSchedule,
@@ -265,7 +265,7 @@ class MockMedicationIntakeProvider extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> deleteIntakeFromId(int? id) => (super.noSuchMethod(
+  _i5.Future<void> deleteIntakeFromId(String? id) => (super.noSuchMethod(
         Invocation.method(
           #deleteIntakeFromId,
           [id],
@@ -328,7 +328,7 @@ class MockMedicationIntakeProvider extends _i1.Mock
       ) as _i9.Date?);
 
   @override
-  _i9.Date? getLastIntakeLocalDateForSchedule(int? scheduleId) =>
+  _i9.Date? getLastIntakeLocalDateForSchedule(String? scheduleId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLastIntakeLocalDateForSchedule,

--- a/test/controllers/supply_items_manager_test.dart
+++ b/test/controllers/supply_items_manager_test.dart
@@ -115,7 +115,7 @@ void main() {
       test('decrements amount by 1', () async {
         // Arrange
         late GenericSupply updatedItem;
-        final item = GenericSupply(id: 7, name: 'Syringe', amount: 5);
+        final item = GenericSupply(id: '7', name: 'Syringe', amount: 5);
         when(mockSupplyItemProvider.updateItem(any)).thenAnswer((inv) async {
           updatedItem = inv.positionalArguments.first as GenericSupply;
         });
@@ -132,7 +132,7 @@ void main() {
       test('increments amount by 1', () async {
         // Arrange
         late GenericSupply updatedItem;
-        final item = GenericSupply(id: 7, name: 'Syringe', amount: 5);
+        final item = GenericSupply(id: '7', name: 'Syringe', amount: 5);
         when(mockSupplyItemProvider.updateItem(any)).thenAnswer((inv) async {
           updatedItem = inv.positionalArguments.first as GenericSupply;
         });
@@ -157,7 +157,7 @@ void main() {
 
       setUpAll(() {
         baseItem = MedicationSupplyItem(
-          id: 0,
+          id: '0',
           name: 'progesterone',
           totalDose: Decimal.parse('30'),
           usedDose: Decimal.parse('10'),
@@ -197,7 +197,7 @@ void main() {
 
       test('previousItem is null and nextItem is valid', () async {
         previousItem = null;
-        nextItem = baseItem.copyWith(id: 1);
+        nextItem = baseItem.copyWith(id: '1');
 
         manager.switchDoses(
             previousItem, nextItem, Decimal.one, Decimal.parse('2'));
@@ -234,7 +234,7 @@ void main() {
 
       test('previousItem and nextItem are different and both valid', () async {
         previousItem = baseItem;
-        nextItem = baseItem.copyWith(id: 1);
+        nextItem = baseItem.copyWith(id: '1');
 
         manager.switchDoses(
             previousItem, nextItem, Decimal.parse('6'), Decimal.parse('7'));

--- a/test/data/model/blood_test_test.dart
+++ b/test/data/model/blood_test_test.dart
@@ -8,7 +8,7 @@ void main() {
     test('toMap and fromMap should preserve values', () {
       // Arrange
       final bloodtest = BloodTest(
-        id: 1,
+        id: '1',
         dateTime: DateTime.utc(2025, 3, 14, 6, 7),
         timeZone: 'Etc/UTC',
         estradiolLevels: UnitValue(Decimal.parse('167.1'), EstradiolUnit.pg_mL),
@@ -36,7 +36,7 @@ void main() {
     test('copyWith overrides only provided fields', () {
       // Arrange
       final original = BloodTest(
-        id: 1,
+        id: '1',
         dateTime: DateTime.utc(2024, 1, 1),
         timeZone: 'Etc/UTC',
         estradiolLevels: UnitValue(Decimal.parse('167.1'), EstradiolUnit.pg_mL),
@@ -64,7 +64,7 @@ void main() {
     test('copyWith does not mutate original object', () {
       // Arrange
       final original = BloodTest(
-        id: 1,
+        id: '1',
         dateTime: DateTime.utc(2024, 1, 1),
         timeZone: 'Etc/UTC',
         estradiolLevels: UnitValue(Decimal.parse('10'), EstradiolUnit.pg_mL),
@@ -73,10 +73,10 @@ void main() {
       );
 
       // Act
-      original.copyWith(id: 2);
+      original.copyWith(id: '2');
 
       // Assert
-      expect(original.id, 1);
+      expect(original.id, '1');
     });
 
     test('constructor throws if dateTime is not UTC', () {
@@ -86,7 +86,7 @@ void main() {
       // Act & Assert
       expect(
         () => BloodTest(
-          id: 1,
+          id: '1',
           dateTime: localDateTime,
           timeZone: 'Etc/UTC',
         ),

--- a/test/data/model/generic_supply_item_test.dart
+++ b/test/data/model/generic_supply_item_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mona/data/model/generic_supply_item.dart';
 
 GenericSupply makeGeneric({
-  int id = 1,
+  String id = '1',
   String name = 'Generic',
   int amount = 1,
 }) {
@@ -19,7 +19,7 @@ void main() {
       test('round-trips all fields', () {
         // Arrange
         final original = makeGeneric(
-          id: 42,
+          id: '42',
           name: 'Syringes',
           amount: 10,
         );
@@ -54,7 +54,7 @@ void main() {
       test('keeps existing values when no overrides are provided', () {
         // Arrange
         final original = makeGeneric(
-          id: 7,
+          id: '7',
           name: 'Original',
           amount: 5,
         );

--- a/test/data/model/medication_intake_test.dart
+++ b/test/data/model/medication_intake_test.dart
@@ -46,12 +46,12 @@ void main() {
       final taken = DateTime.utc(2025, 9, 14, 12, 0);
 
       final intake = MedicationIntake(
-          id: 1,
+          id: '1',
           scheduledDateTime: scheduled,
           dose: Decimal.parse('2.5'),
           takenDateTime: taken,
           takenTimeZone: 'Etc/UTC',
-          scheduleId: 42,
+          scheduleId: '42',
           side: InjectionSide.left,
           molecule: KnownMolecules.estradiol,
           administrationRoute: AdministrationRoute.injection,

--- a/test/data/model/medication_schedule_test.dart
+++ b/test/data/model/medication_schedule_test.dart
@@ -15,7 +15,7 @@ void main() {
     group('MedicationSchedule model', () {
       test('toMap and fromMap should preserve values', () {
         final schedule = MedicationSchedule(
-          id: 1,
+          id: '1',
           name: 'Test Med',
           dose: Decimal.parse('10.5'),
           intervalDays: 7,

--- a/test/data/model/medication_supply_item_test.dart
+++ b/test/data/model/medication_supply_item_test.dart
@@ -7,7 +7,7 @@ import 'package:mona/data/model/molecule.dart';
 import 'package:mona/l10n/app_localizations_en.dart';
 
 MedicationSupplyItem makeMed({
-  int id = 1,
+  String id = '1',
   String name = 'Med',
   String totalDose = '100',
   String usedDose = '0',
@@ -36,7 +36,7 @@ void main() {
       test('round-trips all fields', () {
         // Arrange
         final original = MedicationSupplyItem(
-          id: 1,
+          id: '1',
           name: 'Test Item',
           totalDose: Decimal.parse('100'),
           usedDose: Decimal.parse('20'),

--- a/test/data/model/supply_item_test.dart
+++ b/test/data/model/supply_item_test.dart
@@ -7,7 +7,7 @@ import 'package:mona/data/model/molecule.dart';
 import 'package:mona/data/model/supply_item.dart';
 
 MedicationSupplyItem makeMed({
-  int id = 1,
+  String id = '1',
   String name = 'Med',
   String totalDose = '100',
   String usedDose = '0',
@@ -27,7 +27,7 @@ MedicationSupplyItem makeMed({
 }
 
 GenericSupply makeGeneric({
-  int id = 1,
+  String id = '1',
   String name = 'Generic',
   int amount = 1,
 }) {

--- a/test/data/providers/blood_test_provider_test.dart
+++ b/test/data/providers/blood_test_provider_test.dart
@@ -31,7 +31,7 @@ void main() {
     test('initialization loads bloodtests', () async {
       // Arrange
       await repo.insert(BloodTest(
-        id: 1,
+        id: '1',
         dateTime: DateTime.utc(2025, 3, 14, 6, 7),
         timeZone: 'Etc/UTC',
         estradiolLevels: UnitValue(Decimal.parse('167.1'), EstradiolUnit.pg_mL),
@@ -83,7 +83,7 @@ void main() {
     test('updateBloodTest updates an existing test', () async {
       // Arrange
       repo.insert(BloodTest(
-        id: 1,
+        id: '1',
         dateTime: DateTime.utc(2025, 3, 14, 6, 7),
         timeZone: 'Etc/UTC',
         estradiolLevels: UnitValue(Decimal.parse('167.1'), EstradiolUnit.pg_mL),
@@ -112,7 +112,7 @@ void main() {
     test('deleteBloodTestFromId removes the test', () async {
       // Arrange
       repo.insert(BloodTest(
-        id: 1,
+        id: '1',
         dateTime: DateTime.utc(2025, 3, 14, 6, 7),
         timeZone: 'Etc/UTC',
         estradiolLevels: UnitValue(Decimal.parse('167.1'), EstradiolUnit.pg_mL),
@@ -122,7 +122,7 @@ void main() {
       provider = BloodTestProvider(repository: repo);
 
       // Act
-      await provider.deleteBloodTestFromId(1);
+      await provider.deleteBloodTestFromId('1');
 
       // Assert
       expect(provider.bloodtestsSortedDesc.length, 0);
@@ -131,7 +131,7 @@ void main() {
     test('deleteBloodTest removes the test by object', () async {
       // Arrange
       final bloodtestToDelete = BloodTest(
-        id: 1,
+        id: '1',
         dateTime: DateTime.utc(2025, 3, 14, 6, 7),
         timeZone: 'Etc/UTC',
         estradiolLevels: UnitValue(Decimal.parse('167.1'), EstradiolUnit.pg_mL),
@@ -152,7 +152,7 @@ void main() {
     test('bloodtestsSortedDesc returns test sorted descending', () async {
       provider = BloodTestProvider(repository: repo);
       provider.add(BloodTest(
-        id: 666,
+        id: '666',
         dateTime: DateTime.utc(2025, 5, 4, 3, 0),
         timeZone: 'Etc/UTC',
         estradiolLevels: UnitValue(Decimal.parse('234.5'), EstradiolUnit.pg_mL),
@@ -160,7 +160,7 @@ void main() {
             UnitValue(Decimal.parse('2.34'), TestosteroneUnit.ng_dL),
       ));
       provider.add(BloodTest(
-        id: 667, // ekip
+        id: '667', // ekip
         dateTime: DateTime.utc(2025, 6, 7, 8, 9),
         timeZone: 'Etc/UTC',
         estradiolLevels: UnitValue(Decimal.parse('292.9'), EstradiolUnit.pg_mL),
@@ -168,7 +168,7 @@ void main() {
             UnitValue(Decimal.parse('2.43'), TestosteroneUnit.ng_dL),
       ));
       provider.add(BloodTest(
-        id: 668,
+        id: '668',
         dateTime: DateTime.utc(2025, 3, 2, 1, 0),
         timeZone: 'Etc/UTC',
         estradiolLevels: UnitValue(Decimal.parse('261.2'), EstradiolUnit.pg_mL),
@@ -211,7 +211,7 @@ void main() {
         // Arrange
         provider = BloodTestProvider(repository: repo);
         await provider.add(BloodTest(
-          id: 666,
+          id: '666',
           dateTime: DateTime.utc(2025, 5, 4, 3, 0),
           timeZone: 'Etc/UTC',
           estradiolLevels:
@@ -220,7 +220,7 @@ void main() {
               UnitValue(Decimal.parse('2.34'), TestosteroneUnit.ng_dL),
         ));
         await provider.add(BloodTest(
-          id: 667,
+          id: '667',
           dateTime: DateTime.utc(2025, 5, 5),
           timeZone: 'Etc/UTC',
           estradiolLevels: null,
@@ -240,7 +240,7 @@ void main() {
         // Arrange
         provider = BloodTestProvider(repository: repo);
         await provider.add(BloodTest(
-          id: 668,
+          id: '668',
           dateTime: DateTime.utc(2025, 5, 6, 23, 59),
           timeZone: 'Etc/UTC',
           estradiolLevels:

--- a/test/data/providers/generic_repository_mock.dart
+++ b/test/data/providers/generic_repository_mock.dart
@@ -1,11 +1,11 @@
 import 'package:mockito/mockito.dart';
 import 'package:mona/services/repository.dart';
+import 'package:uuid/uuid.dart';
 
 class GenericRepositoryMock<T extends dynamic> extends Mock
     implements Repository<T> {
   final List<T> _items = [];
-  int _nextId = 1;
-  final T Function(T, int) withId;
+  final T Function(T, String) withId;
 
   GenericRepositoryMock({required this.withId});
 
@@ -13,20 +13,20 @@ class GenericRepositoryMock<T extends dynamic> extends Mock
 
   @override
   Future<int> insert(T item) async {
-    final id = item.id ?? _nextId++;
+    final id = (item as dynamic).id ?? const Uuid().v4();
     final newItem = withId(item, id);
     _items.add(newItem);
-    return (newItem as dynamic).id;
+    return 1; // Return value of insert is usually rowId in sqflite, but for mock it's less important
   }
 
   @override
-  Future<void> update(T item, int id) async {
+  Future<void> update(T item, dynamic id) async {
     final index = _items.indexWhere((i) => (i as dynamic).id == id);
     if (index != -1) _items[index] = item;
   }
 
   @override
-  Future<void> delete(int id) async {
+  Future<void> delete(dynamic id) async {
     _items.removeWhere((i) => (i as dynamic).id == id);
   }
 

--- a/test/data/providers/medication_intake_provider_test.dart
+++ b/test/data/providers/medication_intake_provider_test.dart
@@ -30,7 +30,7 @@ void main() {
     );
     provider = MedicationIntakeProvider(repository: repo);
     repo.insert(MedicationIntake(
-      id: 1,
+      id: '1',
       scheduledDateTime: DateTime(2025, 9, 12, 8, 0),
       dose: Decimal.parse('10.5'),
       takenDateTime: DateTime.utc(2025, 9, 12, 8, 15),
@@ -39,7 +39,7 @@ void main() {
       administrationRoute: AdministrationRoute.gel,
     ));
     repo.insert(MedicationIntake(
-      id: 2,
+      id: '2',
       scheduledDateTime: DateTime(2025, 9, 12, 20, 0),
       dose: Decimal.parse('5.0'),
       molecule: KnownMolecules.estradiol,
@@ -100,12 +100,12 @@ void main() {
 
     test('deleteIntakeFromId removes the item', () async {
       // Act
-      await provider.deleteIntakeFromId(1);
+      await provider.deleteIntakeFromId('1');
 
       // Assert
       expect(
         [provider.intakes.length, provider.intakes.first.id],
-        [1, 2],
+        [1, '2'],
       );
     });
 
@@ -119,7 +119,7 @@ void main() {
       // Assert
       expect(
         [provider.intakes.length, provider.intakes.first.id],
-        [1, 2],
+        [1, '2'],
       );
     });
 
@@ -138,7 +138,7 @@ void main() {
         () async {
       await provider.fetchIntakes();
       provider.add(MedicationIntake(
-        id: 100,
+        id: '100',
         scheduledDateTime: DateTime(2025, 9, 14, 8, 0),
         dose: Decimal.parse('1.0'),
         takenDateTime: DateTime.utc(2025, 9, 14, 8, 10),
@@ -147,14 +147,14 @@ void main() {
         administrationRoute: AdministrationRoute.gel,
       ));
       provider.add(MedicationIntake(
-        id: 101,
+        id: '101',
         scheduledDateTime: DateTime(2025, 9, 15, 8, 0),
         dose: Decimal.parse('1.0'),
         molecule: KnownMolecules.estradiol,
         administrationRoute: AdministrationRoute.gel,
       ));
       provider.add(MedicationIntake(
-        id: 102,
+        id: '102',
         scheduledDateTime: DateTime(2025, 9, 16, 8, 0),
         dose: Decimal.parse('1.0'),
         takenDateTime: DateTime.utc(2025, 9, 16, 8, 10),
@@ -181,16 +181,16 @@ void main() {
         true,
       );
 
-      provider.deleteIntakeFromId(100);
-      provider.deleteIntakeFromId(101);
-      provider.deleteIntakeFromId(102);
+      provider.deleteIntakeFromId('100');
+      provider.deleteIntakeFromId('101');
+      provider.deleteIntakeFromId('102');
     });
 
     group('getTakenIntakesForSchedule', () {
       test('returns only taken intakes for the given schedule', () async {
         repo.insert(MedicationIntake(
-          id: 100,
-          scheduleId: 100,
+          id: '100',
+          scheduleId: '100',
           scheduledDateTime: DateTime(2025, 9, 13, 8, 0),
           dose: Decimal.parse('10.0'),
           takenDateTime: DateTime.utc(2025, 9, 13, 8, 15),
@@ -199,8 +199,8 @@ void main() {
           administrationRoute: AdministrationRoute.gel,
         ));
         repo.insert(MedicationIntake(
-          id: 200,
-          scheduleId: 200,
+          id: '200',
+          scheduleId: '200',
           scheduledDateTime: DateTime(2025, 9, 13, 8, 0),
           dose: Decimal.parse('10.0'),
           takenDateTime: DateTime.utc(2025, 9, 13, 8, 15),
@@ -210,13 +210,13 @@ void main() {
         ));
         await provider.fetchIntakes();
 
-        expect(provider.getTakenIntakesForSchedule(100).length, 1);
+        expect(provider.getTakenIntakesForSchedule('100').length, 1);
       });
 
       test('returns empty list if no taken intakes for schedule', () async {
         await provider.fetchIntakes();
 
-        expect(provider.getTakenIntakesForSchedule(3), isEmpty);
+        expect(provider.getTakenIntakesForSchedule('3'), isEmpty);
       });
     });
 
@@ -228,8 +228,8 @@ void main() {
 
       test('returns the only takenDateTime if list has one intake', () {
         final intake = MedicationIntake(
-          id: 1,
-          scheduleId: 1,
+          id: '1',
+          scheduleId: '1',
           scheduledDateTime: DateTime(2025, 9, 12, 8, 0),
           dose: Decimal.parse('10.5'),
           takenDateTime: DateTime.utc(2025, 9, 12, 8, 15),
@@ -244,8 +244,8 @@ void main() {
 
       test('returns the latest takenDateTime if list has multiple intakes', () {
         final intake1 = MedicationIntake(
-          id: 1,
-          scheduleId: 1,
+          id: '1',
+          scheduleId: '1',
           scheduledDateTime: DateTime(2025, 9, 12, 8, 0),
           dose: Decimal.parse('10.5'),
           takenDateTime: DateTime.utc(2025, 9, 12, 8, 15),
@@ -255,8 +255,8 @@ void main() {
         );
 
         final intake2 = MedicationIntake(
-          id: 2,
-          scheduleId: 1,
+          id: '2',
+          scheduleId: '1',
           scheduledDateTime: DateTime(2025, 9, 12, 20, 0),
           dose: Decimal.parse('5.0'),
           takenDateTime: DateTime.utc(2025, 9, 12, 20, 10),
@@ -266,8 +266,8 @@ void main() {
         );
 
         final intake3 = MedicationIntake(
-          id: 3,
-          scheduleId: 1,
+          id: '3',
+          scheduleId: '1',
           scheduledDateTime: DateTime(2025, 9, 13, 8, 0),
           dose: Decimal.parse('2.5'),
           takenDateTime: DateTime.utc(2025, 9, 13, 8, 5),
@@ -284,8 +284,8 @@ void main() {
       test('handles intakes with same takenDateTime correctly', () {
         final dt = DateTime.utc(2025, 9, 12, 8, 0);
         final intake1 = MedicationIntake(
-          id: 1,
-          scheduleId: 1,
+          id: '1',
+          scheduleId: '1',
           scheduledDateTime: dt,
           dose: Decimal.parse('10.5'),
           takenDateTime: dt,
@@ -295,8 +295,8 @@ void main() {
         );
 
         final intake2 = MedicationIntake(
-          id: 2,
-          scheduleId: 1,
+          id: '2',
+          scheduleId: '1',
           scheduledDateTime: dt,
           dose: Decimal.parse('5.0'),
           takenDateTime: dt,

--- a/test/data/providers/medication_schedule_provider_test.dart
+++ b/test/data/providers/medication_schedule_provider_test.dart
@@ -26,7 +26,7 @@ void main() {
     provider = MedicationScheduleProvider(repository: repo);
 
     repo.insert(MedicationSchedule(
-      id: 1,
+      id: '1',
       name: 'Estradiol',
       dose: Decimal.parse('2.0'),
       intervalDays: 1,
@@ -35,7 +35,7 @@ void main() {
       notificationTimes: List.empty(),
     ));
     repo.insert(MedicationSchedule(
-      id: 2,
+      id: '2',
       name: 'Spironolactone',
       dose: Decimal.parse('100.0'),
       intervalDays: 1,
@@ -91,12 +91,12 @@ void main() {
 
     test('deleteScheduleFromId removes the item', () async {
       // Act
-      await provider.deleteScheduleFromId(1);
+      await provider.deleteScheduleFromId('1');
 
       // Assert
       expect(
         [provider.schedules.length, provider.schedules.first.id],
-        [1, 2],
+        [1, '2'],
       );
     });
 
@@ -110,7 +110,7 @@ void main() {
       // Assert
       expect(
         [provider.schedules.length, provider.schedules.first.id],
-        [1, 2],
+        [1, '2'],
       );
     });
   });

--- a/test/data/providers/supply_item_provider_test.dart
+++ b/test/data/providers/supply_item_provider_test.dart
@@ -10,7 +10,7 @@ import 'package:mona/data/providers/supply_item_provider.dart';
 import 'generic_repository_mock.dart';
 
 MedicationSupplyItem defaultMedicationItem({
-  int? id,
+  String? id,
   String name = 'Med',
   String totalDose = '100',
   String usedDose = '0',
@@ -32,7 +32,7 @@ MedicationSupplyItem defaultMedicationItem({
 }
 
 GenericSupply defaultGenericItem({
-  int? id,
+  String? id,
   String name = 'Generic',
   int amount = 1,
 }) {
@@ -48,7 +48,11 @@ void main() {
   late GenericRepositoryMock<SupplyItem> repo;
 
   setUp(() async {
-    repo = GenericRepositoryMock<SupplyItem>(withId: (item, _) => item);
+    repo = GenericRepositoryMock<SupplyItem>(withId: (item, id) {
+      if (item is MedicationSupplyItem) return item.copyWith(id: id);
+      if (item is GenericSupply) return item.copyWith(id: id);
+      return item;
+    });
     provider = SupplyItemProvider(repository: repo);
     await pumpEventQueue();
   });
@@ -57,14 +61,14 @@ void main() {
     group('fetchItems', () {
       test('loads items from the repository', () async {
         // Arrange
-        await repo.insert(defaultMedicationItem(id: 1));
-        await repo.insert(defaultMedicationItem(id: 2));
+        await repo.insert(defaultMedicationItem(id: '1'));
+        await repo.insert(defaultMedicationItem(id: '2'));
 
         // Act
         await provider.fetchItems();
 
         // Assert
-        expect(provider.items.map((i) => i.id).toList(), [1, 2]);
+        expect(provider.items.map((i) => i.id).toList(), ['1', '2']);
       });
 
       test('notifies listeners', () async {
@@ -83,21 +87,21 @@ void main() {
     group('medicationItems', () {
       test('returns only MedicationSupplyItem entries', () async {
         // Arrange
-        await repo.insert(defaultMedicationItem(id: 1));
-        await repo.insert(defaultGenericItem(id: 2));
+        await repo.insert(defaultMedicationItem(id: '1'));
+        await repo.insert(defaultGenericItem(id: '2'));
         await provider.fetchItems();
 
         // Act
         final result = provider.medicationItems;
 
         // Assert
-        expect(result.map((i) => i.id).toList(), [1]);
+        expect(result.map((i) => i.id).toList(), ['1']);
       });
 
       test('returns an empty list when no medication items are present',
           () async {
         // Arrange
-        await repo.insert(defaultGenericItem(id: 1));
+        await repo.insert(defaultGenericItem(id: '1'));
         await provider.fetchItems();
 
         // Act
@@ -111,20 +115,20 @@ void main() {
     group('genericItems', () {
       test('returns only GenericSupply entries', () async {
         // Arrange
-        await repo.insert(defaultMedicationItem(id: 1));
-        await repo.insert(defaultGenericItem(id: 2));
+        await repo.insert(defaultMedicationItem(id: '1'));
+        await repo.insert(defaultGenericItem(id: '2'));
         await provider.fetchItems();
 
         // Act
         final result = provider.genericItems;
 
         // Assert
-        expect(result.map((i) => i.id).toList(), [2]);
+        expect(result.map((i) => i.id).toList(), ['2']);
       });
 
       test('returns an empty list when no generic items are present', () async {
         // Arrange
-        await repo.insert(defaultMedicationItem(id: 1));
+        await repo.insert(defaultMedicationItem(id: '1'));
         await provider.fetchItems();
 
         // Act
@@ -139,11 +143,11 @@ void main() {
       test('orders most-used (lowest remaining ratio) first', () async {
         // Arrange
         await repo.insert(defaultMedicationItem(
-            id: 1, name: 'A', totalDose: '100', usedDose: '90'));
+            id: '1', name: 'A', totalDose: '100', usedDose: '90'));
         await repo.insert(defaultMedicationItem(
-            id: 2, name: 'B', totalDose: '100', usedDose: '10'));
+            id: '2', name: 'B', totalDose: '100', usedDose: '10'));
         await repo.insert(defaultMedicationItem(
-            id: 3, name: 'C', totalDose: '100', usedDose: '50'));
+            id: '3', name: 'C', totalDose: '100', usedDose: '50'));
         await provider.fetchItems();
 
         // Act
@@ -155,39 +159,39 @@ void main() {
 
       test('ignores generic items', () async {
         // Arrange
-        await repo.insert(defaultMedicationItem(id: 1));
-        await repo.insert(defaultGenericItem(id: 2));
+        await repo.insert(defaultMedicationItem(id: '1'));
+        await repo.insert(defaultGenericItem(id: '2'));
         await provider.fetchItems();
 
         // Act
         final ordered = provider.medicationItemsOrderedByRatio;
 
         // Assert
-        expect(ordered.map((i) => i.id).toList(), [1]);
+        expect(ordered.map((i) => i.id).toList(), ['1']);
       });
     });
 
     group('getItemById', () {
       test('returns the matching item', () async {
         // Arrange
-        await repo.insert(defaultMedicationItem(id: 1));
-        await repo.insert(defaultMedicationItem(id: 2));
+        await repo.insert(defaultMedicationItem(id: '1'));
+        await repo.insert(defaultMedicationItem(id: '2'));
         await provider.fetchItems();
 
         // Act
-        final found = provider.getItemById(2);
+        final found = provider.getItemById('2');
 
         // Assert
-        expect(found?.id, 2);
+        expect(found?.id, '2');
       });
 
       test('returns null when no item matches the id', () async {
         // Arrange
-        await repo.insert(defaultMedicationItem(id: 1));
+        await repo.insert(defaultMedicationItem(id: '1'));
         await provider.fetchItems();
 
         // Act
-        final found = provider.getItemById(999);
+        final found = provider.getItemById('999');
 
         // Assert
         expect(found, isNull);
@@ -195,7 +199,7 @@ void main() {
 
       test('returns null when the id is null', () async {
         // Arrange
-        await repo.insert(defaultMedicationItem(id: 1));
+        await repo.insert(defaultMedicationItem(id: '1'));
         await provider.fetchItems();
 
         // Act
@@ -209,7 +213,7 @@ void main() {
     group('add', () {
       test('inserts the new item into items', () async {
         // Arrange
-        final newItem = defaultMedicationItem(id: 1, name: 'New');
+        final newItem = defaultMedicationItem(id: '1', name: 'New');
 
         // Act
         await provider.add(newItem);
@@ -224,7 +228,7 @@ void main() {
         provider.addListener(() => notifications++);
 
         // Act
-        await provider.add(defaultMedicationItem(id: 1));
+        await provider.add(defaultMedicationItem(id: '1'));
 
         // Assert
         expect(notifications, greaterThan(0));
@@ -234,28 +238,28 @@ void main() {
     group('updateItem', () {
       test('replaces the item in items with the updated one', () async {
         // Arrange
-        await repo.insert(defaultMedicationItem(id: 1, name: 'Original'));
+        await repo.insert(defaultMedicationItem(id: '1', name: 'Original'));
         await provider.fetchItems();
-        final updated = defaultMedicationItem(id: 1, name: 'Updated');
+        final updated = defaultMedicationItem(id: '1', name: 'Updated');
 
         // Act
         await provider.updateItem(updated);
 
         // Assert
-        final result = provider.items.firstWhere((i) => i.id == 1);
+        final result = provider.items.firstWhere((i) => i.id == '1');
         expect(result.name, updated.name);
       });
 
       test('notifies listeners', () async {
         // Arrange
-        await repo.insert(defaultMedicationItem(id: 1));
+        await repo.insert(defaultMedicationItem(id: '1'));
         await provider.fetchItems();
         var notifications = 0;
         provider.addListener(() => notifications++);
 
         // Act
         await provider
-            .updateItem(defaultMedicationItem(id: 1, name: 'Updated'));
+            .updateItem(defaultMedicationItem(id: '1', name: 'Updated'));
 
         // Assert
         expect(notifications, greaterThan(0));
@@ -265,21 +269,21 @@ void main() {
     group('deleteItem', () {
       test('removes the given item from items', () async {
         // Arrange
-        await repo.insert(defaultMedicationItem(id: 1));
-        await repo.insert(defaultMedicationItem(id: 2));
+        await repo.insert(defaultMedicationItem(id: '1'));
+        await repo.insert(defaultMedicationItem(id: '2'));
         await provider.fetchItems();
-        final toDelete = provider.items.firstWhere((i) => i.id == 1);
+        final toDelete = provider.items.firstWhere((i) => i.id == '1');
 
         // Act
         await provider.deleteItem(toDelete);
 
         // Assert
-        expect(provider.items.map((i) => i.id).toList(), [2]);
+        expect(provider.items.map((i) => i.id).toList(), ['2']);
       });
 
       test('notifies listeners', () async {
         // Arrange
-        await repo.insert(defaultMedicationItem(id: 1));
+        await repo.insert(defaultMedicationItem(id: '1'));
         await provider.fetchItems();
         final toDelete = provider.items.first;
         var notifications = 0;
@@ -297,21 +301,21 @@ void main() {
       test('returns the item with the lowest remaining ratio', () async {
         // Arrange
         await repo.insert(defaultMedicationItem(
-          id: 1,
+          id: '1',
           totalDose: '200',
           usedDose: '150',
           route: AdministrationRoute.injection,
           ester: Ester.valerate,
         ));
         await repo.insert(defaultMedicationItem(
-          id: 2,
+          id: '2',
           totalDose: '200',
           usedDose: '50',
           route: AdministrationRoute.injection,
           ester: Ester.valerate,
         ));
         await repo.insert(defaultMedicationItem(
-          id: 3,
+          id: '3',
           totalDose: '200',
           usedDose: '100',
           route: AdministrationRoute.injection,
@@ -327,19 +331,19 @@ void main() {
         );
 
         // Assert
-        expect(mostUsed?.id, 1);
+        expect(mostUsed?.id, '1');
       });
 
       test('ignores items with a different administration route', () async {
         // Arrange
         await repo.insert(defaultMedicationItem(
-          id: 1,
+          id: '1',
           usedDose: '50',
           route: AdministrationRoute.injection,
           ester: Ester.valerate,
         ));
         await repo.insert(defaultMedicationItem(
-          id: 2,
+          id: '2',
           usedDose: '99',
           route: AdministrationRoute.oral,
         ));
@@ -353,19 +357,19 @@ void main() {
         );
 
         // Assert
-        expect(mostUsed?.id, 1);
+        expect(mostUsed?.id, '1');
       });
 
       test('ignores items with a different molecule', () async {
         // Arrange
         await repo.insert(defaultMedicationItem(
-          id: 1,
+          id: '1',
           molecule: KnownMolecules.estradiol,
           route: AdministrationRoute.injection,
           ester: Ester.valerate,
         ));
         await repo.insert(defaultMedicationItem(
-          id: 2,
+          id: '2',
           usedDose: '99',
           molecule: KnownMolecules.progesterone,
           route: AdministrationRoute.injection,
@@ -381,18 +385,18 @@ void main() {
         );
 
         // Assert
-        expect(mostUsed?.id, 1);
+        expect(mostUsed?.id, '1');
       });
 
       test('ignores items with a different ester', () async {
         // Arrange
         await repo.insert(defaultMedicationItem(
-          id: 1,
+          id: '1',
           route: AdministrationRoute.injection,
           ester: Ester.valerate,
         ));
         await repo.insert(defaultMedicationItem(
-          id: 2,
+          id: '2',
           usedDose: '99',
           route: AdministrationRoute.injection,
           ester: Ester.enanthate,
@@ -407,12 +411,12 @@ void main() {
         );
 
         // Assert
-        expect(mostUsed?.id, 1);
+        expect(mostUsed?.id, '1');
       });
 
       test('returns null when there are no medication items', () async {
         // Arrange
-        await repo.insert(defaultGenericItem(id: 1));
+        await repo.insert(defaultGenericItem(id: '1'));
         await provider.fetchItems();
 
         // Act
@@ -429,7 +433,7 @@ void main() {
       test('returns null when no medication item matches', () async {
         // Arrange
         await repo.insert(
-            defaultMedicationItem(id: 1, route: AdministrationRoute.oral));
+            defaultMedicationItem(id: '1', route: AdministrationRoute.oral));
         await provider.fetchItems();
 
         // Act
@@ -448,21 +452,21 @@ void main() {
       test('returns matching items ordered by most used first', () async {
         // Arrange
         await repo.insert(defaultMedicationItem(
-          id: 1,
+          id: '1',
           totalDose: '200',
           usedDose: '150',
           route: AdministrationRoute.injection,
           ester: Ester.valerate,
         ));
         await repo.insert(defaultMedicationItem(
-          id: 2,
+          id: '2',
           totalDose: '200',
           usedDose: '50',
           route: AdministrationRoute.injection,
           ester: Ester.valerate,
         ));
         await repo.insert(defaultMedicationItem(
-          id: 3,
+          id: '3',
           totalDose: '200',
           usedDose: '100',
           route: AdministrationRoute.injection,
@@ -478,18 +482,18 @@ void main() {
         );
 
         // Assert
-        expect(items.map((i) => i.id).toList(), [1, 3, 2]);
+        expect(items.map((i) => i.id).toList(), ['1', '3', '2']);
       });
 
       test('filters out items with a different molecule', () async {
         // Arrange
         await repo.insert(defaultMedicationItem(
-          id: 1,
+          id: '1',
           route: AdministrationRoute.injection,
           ester: Ester.valerate,
         ));
         await repo.insert(defaultMedicationItem(
-          id: 2,
+          id: '2',
           molecule: KnownMolecules.progesterone,
           route: AdministrationRoute.injection,
           ester: Ester.valerate,
@@ -504,18 +508,18 @@ void main() {
         );
 
         // Assert
-        expect(items.map((i) => i.id).toList(), [1]);
+        expect(items.map((i) => i.id).toList(), ['1']);
       });
 
       test('filters out items with a different administration route', () async {
         // Arrange
         await repo.insert(defaultMedicationItem(
-          id: 1,
+          id: '1',
           route: AdministrationRoute.injection,
           ester: Ester.valerate,
         ));
         await repo.insert(
-            defaultMedicationItem(id: 2, route: AdministrationRoute.oral));
+            defaultMedicationItem(id: '2', route: AdministrationRoute.oral));
         await provider.fetchItems();
 
         // Act
@@ -526,18 +530,18 @@ void main() {
         );
 
         // Assert
-        expect(items.map((i) => i.id).toList(), [1]);
+        expect(items.map((i) => i.id).toList(), ['1']);
       });
 
       test('filters out items with a different ester', () async {
         // Arrange
         await repo.insert(defaultMedicationItem(
-          id: 1,
+          id: '1',
           route: AdministrationRoute.injection,
           ester: Ester.valerate,
         ));
         await repo.insert(defaultMedicationItem(
-          id: 2,
+          id: '2',
           route: AdministrationRoute.injection,
           ester: Ester.enanthate,
         ));
@@ -551,13 +555,13 @@ void main() {
         );
 
         // Assert
-        expect(items.map((i) => i.id).toList(), [1]);
+        expect(items.map((i) => i.id).toList(), ['1']);
       });
 
       test('returns an empty list when there are no medication items',
           () async {
         // Arrange
-        await repo.insert(defaultGenericItem(id: 1));
+        await repo.insert(defaultGenericItem(id: '1'));
         await provider.fetchItems();
 
         // Act
@@ -574,7 +578,7 @@ void main() {
       test('returns an empty list when no medication item matches', () async {
         // Arrange
         await repo.insert(
-            defaultMedicationItem(id: 1, route: AdministrationRoute.oral));
+            defaultMedicationItem(id: '1', route: AdministrationRoute.oral));
         await provider.fetchItems();
 
         // Act

--- a/test/mocks/mocks.mocks.dart
+++ b/test/mocks/mocks.mocks.dart
@@ -274,7 +274,7 @@ class MockMedicationIntakeProvider extends _i1.Mock
       ) as bool);
 
   @override
-  List<_i13.MedicationIntake> getTakenIntakesForSchedule(int? scheduleId) =>
+  List<_i13.MedicationIntake> getTakenIntakesForSchedule(String? scheduleId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getTakenIntakesForSchedule,
@@ -294,7 +294,7 @@ class MockMedicationIntakeProvider extends _i1.Mock
       ) as _i7.Future<void>);
 
   @override
-  _i7.Future<void> deleteIntakeFromId(int? id) => (super.noSuchMethod(
+  _i7.Future<void> deleteIntakeFromId(String? id) => (super.noSuchMethod(
         Invocation.method(
           #deleteIntakeFromId,
           [id],
@@ -353,7 +353,7 @@ class MockMedicationIntakeProvider extends _i1.Mock
       )) as _i14.Date?);
 
   @override
-  _i14.Date? getLastIntakeLocalDateForSchedule(int? scheduleId) =>
+  _i14.Date? getLastIntakeLocalDateForSchedule(String? scheduleId) =>
       (super.noSuchMethod(Invocation.method(
         #getLastIntakeLocalDateForSchedule,
         [scheduleId],
@@ -433,7 +433,7 @@ class MockMedicationScheduleProvider extends _i1.Mock
       ) as bool);
 
   @override
-  _i16.MedicationSchedule? getScheduleById(int? id) =>
+  _i16.MedicationSchedule? getScheduleById(String? id) =>
       (super.noSuchMethod(Invocation.method(
         #getScheduleById,
         [id],
@@ -450,7 +450,7 @@ class MockMedicationScheduleProvider extends _i1.Mock
       ) as _i7.Future<void>);
 
   @override
-  _i7.Future<void> deleteScheduleFromId(int? id) => (super.noSuchMethod(
+  _i7.Future<void> deleteScheduleFromId(String? id) => (super.noSuchMethod(
         Invocation.method(
           #deleteScheduleFromId,
           [id],

--- a/test/services/repository_test.dart
+++ b/test/services/repository_test.dart
@@ -40,12 +40,12 @@ void main() {
         administrationRoute: AdministrationRoute.oral,
       );
 
-      int insertedId = await repository.insert(item);
+      await repository.insert(item);
       final items = await repository.getAll();
 
       expect(
         [items.length, items[0].id],
-        [1, insertedId],
+        [1, item.id],
       );
     });
 
@@ -57,7 +57,8 @@ void main() {
         molecule: KnownMolecules.estradiol,
         administrationRoute: AdministrationRoute.oral,
       );
-      int id = await repository.insert(item);
+      await repository.insert(item);
+      final id = item.id;
       final updatedItem = MedicationSupplyItem(
         name: 'h',
         id: id,
@@ -84,7 +85,8 @@ void main() {
         molecule: KnownMolecules.estradiol,
         administrationRoute: AdministrationRoute.oral,
       );
-      int id = await repository.insert(item);
+      await repository.insert(item);
+      final id = item.id;
 
       await repository.delete(id);
 
@@ -94,7 +96,7 @@ void main() {
 
     test('Only delete the specified SupplyItem', () async {
       final item1 = MedicationSupplyItem(
-        id: 1,
+        id: '1',
         name: 'g',
         totalDose: Decimal.parse('1'),
         concentration: Decimal.parse('1'),
@@ -102,22 +104,22 @@ void main() {
         administrationRoute: AdministrationRoute.oral,
       );
       final item2 = MedicationSupplyItem(
-        id: 2,
+        id: '2',
         name: 'h',
         totalDose: Decimal.parse('2'),
         concentration: Decimal.parse('1'),
         molecule: KnownMolecules.estradiol,
         administrationRoute: AdministrationRoute.oral,
       );
-      int id1 = await repository.insert(item1);
-      int id2 = await repository.insert(item2);
+      await repository.insert(item1);
+      await repository.insert(item2);
 
-      await repository.delete(id1);
+      await repository.delete(item1.id);
 
       final remainingItems = await repository.getAll();
       expect(
         [remainingItems.length, remainingItems[0].id],
-        [1, id2],
+        [1, item2.id],
       );
     });
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->

As we are planning on developping a backend sync service, we need to move to UUIDs to prevent ID collisions when multiple offline devices attempt to sync.

### Type of change
<!--- What types of changes does your code introduce? Keep all the lines that apply: -->
- db Version bumped to 8
- int IDs are now string IDs (uuids)

### Files
[Sample Data (V7, IDs)](https://github.com/user-attachments/files/27719033/sample_data.json)
[Migrated exported Data (V8, UUIDs)](https://github.com/user-attachments/files/27719046/exported_data_uuid.json)

