### PR TITLE
Reproducible builds

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -197,9 +197,9 @@ jobs:
           path: build/app/outputs/flutter-apk/mona-*.apk
           retention-days: 7
 
-  # ── Build Android release App Bundle + split-per-ABI APKs (signed, Play) ──
-  build_android_play:
-    name: Build Android AAB and APKs (play, signed)
+  # ── Build Android release App Bundle + split-per-ABI APKs (signed, Store) ─
+  build_android_store:
+    name: Build Android AAB and APKs (store, signed)
     runs-on: ubuntu-latest
     needs: [bump_version]
 
@@ -240,10 +240,10 @@ jobs:
           EOF
 
       - name: Build release App Bundle
-        run: flutter build appbundle --release --flavor play
+        run: flutter build appbundle --release --flavor store
 
       - name: Build release APKs (split per ABI)
-        run: flutter build apk --release --flavor play --split-per-abi
+        run: flutter build apk --release --flavor store --split-per-abi
 
       - name: Clean up signing files
         if: always()
@@ -254,29 +254,29 @@ jobs:
       - name: Rename AAB
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          mv build/app/outputs/bundle/playRelease/app-play-release.aab "build/app/outputs/bundle/playRelease/mona-${VERSION}.aab"
+          mv build/app/outputs/bundle/storeRelease/app-store-release.aab "build/app/outputs/bundle/storeRelease/mona-${VERSION}.aab"
 
       # Rename per-ABI APKs to mona-store-<abi>.apk
       - name: Rename per-ABI APKs
         run: |
           cd build/app/outputs/flutter-apk
-          for f in app-*-play-release.apk; do
+          for f in app-*-store-release.apk; do
             abi="${f#app-}"
-            abi="${abi%-play-release.apk}"
+            abi="${abi%-store-release.apk}"
             mv "$f" "mona-store-${abi}.apk"
           done
 
       - name: Upload AAB artifact
         uses: actions/upload-artifact@v6
         with:
-          name: android-release-aab-play
-          path: build/app/outputs/bundle/playRelease/mona-*.aab
+          name: android-release-aab-store
+          path: build/app/outputs/bundle/storeRelease/mona-*.aab
           retention-days: 7
 
-      - name: Upload play APK artifacts
+      - name: Upload store APK artifacts
         uses: actions/upload-artifact@v6
         with:
-          name: android-release-apk-play
+          name: android-release-apk-store
           path: build/app/outputs/flutter-apk/mona-store-*.apk
           retention-days: 7
 
@@ -284,7 +284,7 @@ jobs:
   create_release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [build_android_standalone, build_android_play]
+    needs: [build_android_standalone, build_android_store]
     permissions:
       contents: write
 
@@ -295,10 +295,10 @@ jobs:
           name: android-release-apk-standalone
           path: artifacts/
 
-      - name: Download play split-per-ABI APK artifacts
+      - name: Download store split-per-ABI APK artifacts
         uses: actions/download-artifact@v6
         with:
-          name: android-release-apk-play
+          name: android-release-apk-store
           path: artifacts/
 
       # Create the release and attach the APKs.

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1,10 +1,16 @@
 name: CI - release
 
-# Trigger on version tags pushed after merging dev into main (e.g. v1.2.3)
+# Manually triggered from the Actions tab (or `gh workflow run`) with the
+# release version as input. CI bumps the version, commits to main, and creates
+# the matching `vX.Y.Z` tag on that bumped commit.
+
 on:
-  push:
-    tags:
-      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (e.g. 1.8.0)"
+        required: true
+        type: string
 
 jobs:
   # ── Format ────────────────────────────────────────────────────────────────
@@ -70,77 +76,82 @@ jobs:
       - name: Run tests with coverage
         run: flutter test --coverage
 
-  # ── Version bump commit ───────────────────────────────────────────────────
+  # ── Version bump + tag (on the bumped commit) ─────────────────────────────
   bump_version:
-    name: Bump version
+    name: Bump version and tag
     runs-on: ubuntu-latest
-    # Only run after all quality checks pass
     needs: [format, analyze, test_coverage]
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
 
     steps:
       - name: Checkout repository
-        # Needs a PAT (not the default GITHUB_TOKEN) so the push is allowed
-        # on a branch protected by branch protection rules.
-        # Create a fine-grained PAT with "Contents: Read and write" on this repo
-        # and store it as the secret VERSION_BUMP_PAT.
         uses: actions/checkout@v6
         with:
           token: ${{ secrets.VERSION_BUMP_PAT }}
           ref: main
 
-      # Extract version number from the tag (strips the leading "v")
-      - name: Parse version from tag
+      - name: Validate and parse version
         id: version
         env:
+          INPUT_VERSION: ${{ inputs.version }}
           RUN_NUMBER: ${{ github.run_number }}
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          if ! [[ "$INPUT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Version must be MAJOR.MINOR.PATCH (got: '$INPUT_VERSION')"
+            exit 1
+          fi
+          if git ls-remote --tags --exit-code origin "refs/tags/v${INPUT_VERSION}" >/dev/null 2>&1; then
+            echo "::error::Tag v${INPUT_VERSION} already exists on origin"
+            exit 1
+          fi
           BUILD_NUMBER=$((RUN_NUMBER + 5))
-          echo "version=$VERSION"       >> "$GITHUB_OUTPUT"
-          echo "build_number=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
+          {
+            echo "version=${INPUT_VERSION}"
+            echo "tag=v${INPUT_VERSION}"
+            echo "build_number=${BUILD_NUMBER}"
+          } >> "$GITHUB_OUTPUT"
 
-      # Update pubspec.yaml: replace the version line
       - name: Update pubspec.yaml
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          BUILD: ${{ steps.version.outputs.build_number }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          BUILD="${{ steps.version.outputs.build_number }}"
           sed -i "s/^version: .*/version: ${VERSION}+${BUILD}/" pubspec.yaml
 
-      # Update MARKETING_VERSION in the Runner target only (not RunnerTests).
-      # RunnerTests always has MARKETING_VERSION = 1.0 so we only replace
-      # occurrences that match the previous app version (read from pubspec
-      # before the sed above ran — we re-read the file on disk).
       - name: Update MARKETING_VERSION in project.pbxproj
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           FILE="ios/Runner.xcodeproj/project.pbxproj"
           # Read the old version straight from the pbxproj (e.g. "1.5.2")
           OLD_VERSION=$(grep -m1 'MARKETING_VERSION = [0-9]' "$FILE" \
             | sed 's/.*MARKETING_VERSION = \([^;]*\);.*/\1/')
           sed -i "s/MARKETING_VERSION = ${OLD_VERSION};/MARKETING_VERSION = ${VERSION};/g" "$FILE"
 
-      # Commit the two modified files
-      - name: Commit version bump
+      - name: Commit bump and push tag
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
           git config user.name  "délia"
           git config user.email "delia@cheminot.net"
           git add pubspec.yaml ios/Runner.xcodeproj/project.pbxproj
-          git commit -m "chore: update version"
-          git push origin main
+          git commit -m "chore: release ${TAG}"
+          git tag "${TAG}"
+          git push --atomic origin main "refs/tags/${TAG}"
 
-  # ── Build Android release APK (signed) ────────────────────────────────────
+  # ── Build Android release APK ─────────────────────────────────────────────
   build_android_standalone:
-    name: Build Android APK (standalone, signed)
+    name: Build Android APK (standalone)
     runs-on: ubuntu-latest
-    # Run after the version bump so the APK embeds the correct version
     needs: [bump_version]
 
     steps:
-      # Checkout main again so we get the version bump commit
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          ref: main
+          ref: ${{ needs.bump_version.outputs.tag }}
 
       - name: Set up Java 17
         uses: actions/setup-java@v5
@@ -158,13 +169,11 @@ jobs:
       - name: Get dependencies
         run: flutter pub get
 
-      # Decode the keystore stored as a base64 secret and write it to disk
       - name: Decode keystore
         run: |
           echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode \
             > android/app/upload-keystore.jks
 
-      # Write key.properties so Gradle can find the signing config
       - name: Create key.properties
         run: |
           cat <<EOF > android/key.properties
@@ -175,19 +184,20 @@ jobs:
           EOF
 
       - name: Build release APK
-        run: flutter build apk --release --flavor standalone
+        run: |
+          flutter clean
+          flutter build apk --release --flavor standalone
 
-      # Remove signing artifacts from the runner before the job ends
       - name: Clean up signing files
         if: always()
         run: |
           rm -f android/app/upload-keystore.jks
           rm -f android/key.properties
 
-      # Rename the APK to mona-[version].apk (strips the leading "v" from the tag)
       - name: Rename APK
+        env:
+          VERSION: ${{ needs.bump_version.outputs.version }}
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
           mv build/app/outputs/flutter-apk/app-standalone-release.apk "build/app/outputs/flutter-apk/mona-${VERSION}.apk"
 
       - name: Upload APK artifact
@@ -197,9 +207,9 @@ jobs:
           path: build/app/outputs/flutter-apk/mona-*.apk
           retention-days: 7
 
-  # ── Build Android release App Bundle + split-per-ABI APKs (signed, Store) ─
+  # ── Build Android release App Bundle + split-per-ABI APKs (Store version) ─
   build_android_store:
-    name: Build Android AAB and APKs (store, signed)
+    name: Build Android AAB and APKs (store)
     runs-on: ubuntu-latest
     needs: [bump_version]
 
@@ -207,7 +217,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          ref: main
+          ref: ${{ needs.bump_version.outputs.tag }}
 
       - name: Set up Java 17
         uses: actions/setup-java@v5
@@ -240,10 +250,14 @@ jobs:
           EOF
 
       - name: Build release App Bundle
-        run: flutter build appbundle --release --flavor store
+        run: |
+          flutter clean
+          flutter build appbundle --release --flavor store
 
       - name: Build release APKs (split per ABI)
-        run: flutter build apk --release --flavor store --split-per-abi
+        run: |
+          flutter clean
+          flutter build apk --release --flavor store --split-per-abi
 
       - name: Clean up signing files
         if: always()
@@ -252,11 +266,11 @@ jobs:
           rm -f android/key.properties
 
       - name: Rename AAB
+        env:
+          VERSION: ${{ needs.bump_version.outputs.version }}
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
           mv build/app/outputs/bundle/storeRelease/app-store-release.aab "build/app/outputs/bundle/storeRelease/mona-${VERSION}.aab"
 
-      # Rename per-ABI APKs to mona-store-<abi>.apk
       - name: Rename per-ABI APKs
         run: |
           cd build/app/outputs/flutter-apk
@@ -284,7 +298,7 @@ jobs:
   create_release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [build_android_standalone, build_android_store]
+    needs: [bump_version, build_android_standalone, build_android_store]
     permissions:
       contents: write
 
@@ -301,13 +315,11 @@ jobs:
           name: android-release-apk-store
           path: artifacts/
 
-      # Create the release and attach the APKs.
-      # The tag name becomes the release title (e.g. "v1.2.3").
       - name: Create release and upload APKs
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_name }}
-          name: ${{ github.ref_name }}
+          tag_name: ${{ needs.bump_version.outputs.tag }}
+          name: ${{ needs.bump_version.outputs.tag }}
           files: |
             artifacts/mona-*.apk
-          generate_release_notes: false
+          generate_release_notes: true

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -197,9 +197,9 @@ jobs:
           path: build/app/outputs/flutter-apk/mona-*.apk
           retention-days: 7
 
-  # ── Build Android release App Bundle (signed, Play Store) ─────────────────
+  # ── Build Android release App Bundle + split-per-ABI APKs (signed, Play) ──
   build_android_play:
-    name: Build Android AAB (play, signed)
+    name: Build Android AAB and APKs (play, signed)
     runs-on: ubuntu-latest
     needs: [bump_version]
 
@@ -242,6 +242,9 @@ jobs:
       - name: Build release App Bundle
         run: flutter build appbundle --release --flavor play
 
+      - name: Build release APKs (split per ABI)
+        run: flutter build apk --release --flavor play --split-per-abi
+
       - name: Clean up signing files
         if: always()
         run: |
@@ -253,6 +256,16 @@ jobs:
           VERSION="${GITHUB_REF_NAME#v}"
           mv build/app/outputs/bundle/playRelease/app-play-release.aab "build/app/outputs/bundle/playRelease/mona-${VERSION}.aab"
 
+      # Rename per-ABI APKs to mona-store-<abi>.apk
+      - name: Rename per-ABI APKs
+        run: |
+          cd build/app/outputs/flutter-apk
+          for f in app-*-play-release.apk; do
+            abi="${f#app-}"
+            abi="${abi%-play-release.apk}"
+            mv "$f" "mona-store-${abi}.apk"
+          done
+
       - name: Upload AAB artifact
         uses: actions/upload-artifact@v6
         with:
@@ -260,11 +273,18 @@ jobs:
           path: build/app/outputs/bundle/playRelease/mona-*.aab
           retention-days: 7
 
+      - name: Upload play APK artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: android-release-apk-play
+          path: build/app/outputs/flutter-apk/mona-store-*.apk
+          retention-days: 7
+
   # ── GitHub Release ─────────────────────────────────────────────────────────
   create_release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [build_android_standalone]
+    needs: [build_android_standalone, build_android_play]
     permissions:
       contents: write
 
@@ -275,7 +295,13 @@ jobs:
           name: android-release-apk-standalone
           path: artifacts/
 
-      # Create the release and attach the APK.
+      - name: Download play split-per-ABI APK artifacts
+        uses: actions/download-artifact@v6
+        with:
+          name: android-release-apk-play
+          path: artifacts/
+
+      # Create the release and attach the APKs.
       # The tag name becomes the release title (e.g. "v1.2.3").
       - name: Create release and upload APKs
         uses: softprops/action-gh-release@v2

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -57,11 +57,11 @@ android {
         versionName = flutterVersionName
     }
 
-    // `play`: Google Play (no REQUEST_INSTALL_PACKAGES; Dart hides sideload update UI).
-    // `standalone`: signed sideload / GitHub APK (in-app updates + install permission).
+    // `store`: App stores (no REQUEST_INSTALL_PACKAGES; Dart hides sideload update UI).
+    // `standalone`: sideload / GitHub APK (in-app updates + install permission).
     flavorDimensions "distribution"
     productFlavors {
-        play {
+        store {
             dimension "distribution"
         }
         standalone {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -38,6 +38,14 @@ android {
         includeInBundle = false
     }
 
+    // Reproducible builds hygiene: PNG crunching during the build and runtime
+    // PNG generation from vector drawables both produce non-deterministic
+    // bytes between machines. Launcher icons are pre-rendered via
+    // flutter_launcher_icons, so disabling these has no visible effect.
+    aaptOptions {
+        cruncherEnabled = false
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
@@ -55,6 +63,17 @@ android {
         targetSdkVersion flutter.targetSdkVersion
         versionCode = flutterVersionCode.toInteger()
         versionName = flutterVersionName
+        // Empty list disables generating density-specific PNGs from vector
+        // drawables at build time (nondeterministic across machines).
+        vectorDrawables.generatedDensities = []
+        // Defensive: strip ELF build-id from any plugin-compiled native libs.
+        // Most plugins ship prebuilt .so files (unaffected), but a few use
+        // CMake — this avoids a random build-id sneaking into their output.
+        externalNativeBuild {
+            cmake {
+                cFlags "-Wl,--build-id=none"
+            }
+        }
     }
 
     // `store`: App stores (no REQUEST_INSTALL_PACKAGES; Dart hides sideload update UI).

--- a/android/app/src/store/AndroidManifest.xml
+++ b/android/app/src/store/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-    <!-- Stripped from play merges: declared by open_filex (unused in this flavor). -->
+    <!-- Stripped from store merges: declared by open_filex (unused in this flavor). -->
     <uses-permission
         android:name="android.permission.READ_MEDIA_IMAGES"
         tools:node="remove" />

--- a/lib/distribution.dart
+++ b/lib/distribution.dart
@@ -1,12 +1,12 @@
 /// Android `--flavor` is forwarded as a compile-time define by the Flutter tool.
-/// See `android/app/build.gradle` (`play`, `standalone`).
+/// See `android/app/build.gradle` (`store`, `standalone`).
 const String _flutterAppFlavor = String.fromEnvironment(
   'FLUTTER_APP_FLAVOR',
   defaultValue: '',
 );
 
-/// Play Store build: no sideload/APK update UI and no [REQUEST_INSTALL_PACKAGES].
-bool get isPlayStoreDistribution => _flutterAppFlavor == 'play';
+/// App stores build: no sideload/APK update UI and no [REQUEST_INSTALL_PACKAGES].
+bool get isStoreDistribution => _flutterAppFlavor == 'store';
 
 /// Signed sideload build distributed as a single GitHub APK named `mona-*.apk`.
 bool get isStandaloneDistribution => _flutterAppFlavor == 'standalone';

--- a/lib/services/update_service.dart
+++ b/lib/services/update_service.dart
@@ -24,7 +24,7 @@ class UpdateService {
   }
 
   Future<bool> isUpdateAvailable() async {
-    if (isPlayStoreDistribution || !Platform.isAndroid) return false;
+    if (isStoreDistribution || !Platform.isAndroid) return false;
     try {
       final packageInfo = await PackageInfo.fromPlatform();
       final data = await _fetchLatestRelease();
@@ -44,7 +44,7 @@ class UpdateService {
   }
 
   Future<void> checkForUpdates(BuildContext context) async {
-    if (isPlayStoreDistribution || !Platform.isAndroid) return;
+    if (isStoreDistribution || !Platform.isAndroid) return;
     final l10n = context.l10n;
 
     try {

--- a/lib/services/update_service.dart
+++ b/lib/services/update_service.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:mona/distribution.dart';
@@ -97,37 +96,12 @@ class UpdateService {
         assets.where((a) => a['name'].toString().endsWith('.apk')).toList();
     if (apkAssets.isEmpty) return null;
 
-    if (isStandaloneDistribution) {
-      for (var asset in apkAssets) {
-        if (asset['name'].toString().toLowerCase().contains('mona-')) {
-          return asset;
-        }
-      }
-      return null;
-    }
-
-    final deviceInfo = DeviceInfoPlugin();
-    final androidInfo = await deviceInfo.androidInfo;
-    final supportedAbis = androidInfo.supportedAbis;
-
-    for (String abi in supportedAbis) {
-      for (var asset in apkAssets) {
-        if (asset['name']
-            .toString()
-            .toLowerCase()
-            .contains(abi.toLowerCase())) {
-          return asset;
-        }
+    for (var asset in apkAssets) {
+      if (asset['name'].toString().toLowerCase().contains('mona-')) {
+        return asset;
       }
     }
-
-    final universalAssets = apkAssets
-        .where((a) => a['name'].toString().toLowerCase().contains('universal'))
-        .toList();
-
-    if (universalAssets.isNotEmpty) return universalAssets.first;
-
-    return apkAssets.first;
+    return null;
   }
 
   void _showUpdateDialog(BuildContext context, String current, String latest,

--- a/lib/services/update_service.dart
+++ b/lib/services/update_service.dart
@@ -96,7 +96,8 @@ class UpdateService {
     if (apkAssets.isEmpty) return null;
 
     for (var asset in apkAssets) {
-      if (asset['name'].toString().toLowerCase().contains('mona-')) {
+      final assetName = asset['name'].toString().toLowerCase();
+      if (assetName.contains('mona-') && !assetName.contains('store')) {
         return asset;
       }
     }

--- a/lib/services/update_service.dart
+++ b/lib/services/update_service.dart
@@ -62,13 +62,12 @@ class UpdateService {
         if (!context.mounted) return;
 
         if (latest > current) {
-          final bestAsset = await _getBestAssetForDevice(assets);
+          final asset = _getAsset(assets);
 
           if (!context.mounted) return;
 
-          if (bestAsset != null) {
-            _showUpdateDialog(
-                context, currentVersion, latestVersion, bestAsset);
+          if (asset != null) {
+            _showUpdateDialog(context, currentVersion, latestVersion, asset);
           } else {
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(content: Text(l10n.updateNoCompatibleApk)),
@@ -91,7 +90,7 @@ class UpdateService {
     }
   }
 
-  Future<Map<String, dynamic>?> _getBestAssetForDevice(List assets) async {
+  Map<String, dynamic>? _getAsset(List assets) {
     final apkAssets =
         assets.where((a) => a['name'].toString().endsWith('.apk')).toList();
     if (apkAssets.isEmpty) return null;

--- a/lib/ui/views/home/settings/settings_page.dart
+++ b/lib/ui/views/home/settings/settings_page.dart
@@ -272,7 +272,7 @@ class _SettingsPageState extends State<SettingsPage>
                   MaterialPageRoute<void>(builder: (context) => UnitsPage()));
             },
           ),
-          if (Platform.isAndroid && !isPlayStoreDistribution) ...[
+          if (Platform.isAndroid && !isStoreDistribution) ...[
             const Divider(),
             Padding(
               padding: const EdgeInsets.symmetric(

--- a/lib/ui/views/main_page.dart
+++ b/lib/ui/views/main_page.dart
@@ -33,7 +33,7 @@ class _MainPageState extends State<MainPage> {
   }
 
   Future<void> _runAutomaticUpdateCheck() async {
-    if (isPlayStoreDistribution) return;
+    if (isStoreDistribution) return;
     final prefs = context.read<PreferencesService>();
     if (!prefs.autoCheckUpdatesEnabled) return;
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,7 +5,6 @@
 import FlutterMacOS
 import Foundation
 
-import device_info_plus
 import dynamic_system_colors
 import file_picker
 import flutter_local_notifications
@@ -17,7 +16,6 @@ import sqflite_darwin
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
-  DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   DynamicColorPlugin.register(with: registry.registrar(forPlugin: "DynamicColorPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -233,22 +233,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.4"
-  device_info_plus:
-    dependency: "direct main"
-    description:
-      name: device_info_plus
-      sha256: "4df8babf73058181227e18b08e6ea3520cf5fc5d796888d33b7cb0f33f984b7c"
-      url: "https://pub.dev"
-    source: hosted
-    version: "12.3.0"
-  device_info_plus_platform_interface:
-    dependency: transitive
-    description:
-      name: device_info_plus_platform_interface
-      sha256: e1ea89119e34903dca74b883d0dd78eb762814f97fb6c76f35e9ff74d261a18f
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.0.3"
   dynamic_system_colors:
     dependency: "direct main"
     description:
@@ -1235,14 +1219,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.15.0"
-  win32_registry:
-    dependency: transitive
-    description:
-      name: win32_registry
-      sha256: "6f1b564492d0147b330dd794fee8f512cec4977957f310f9951b5f9d83618dae"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,7 +58,6 @@ dependencies:
   http: ^1.2.0
   package_info_plus: ^9.0.0
   url_launcher: ^6.2.6
-  device_info_plus: ^12.3.0
   path_provider: ^2.1.4
   open_filex: ^4.5.0
   pub_semver: ^2.2.0


### PR DESCRIPTION
### Description

Prep work for publishing to IzzyOnDroid (and, eventually, F-Droid Main): make Android release builds reproducible, generalise the `play` flavor into a multi-store `store` flavor, and produce per-ABI APKs to stay under IzzyOnDroid's 30 MB asset limit. The in-app updater is updated to ignore those new store APKs so sideload users keep getting the universal `mona-*.apk`.

Related to issue: #194

### What changed

**Reproducible builds (`android/app/build.gradle`)**
- `aaptOptions.cruncherEnabled = false` — disables PNG crunching, which produces non-deterministic bytes between machines. Launcher icons are pre-rendered via `flutter_launcher_icons`, so this is invisible to users.
- `vectorDrawables.generatedDensities = []` — disables build-time density-specific PNG generation from vector drawables (also non-deterministic).
- `externalNativeBuild.cmake.cFlags "-Wl,--build-id=none"` — defensive: strips the ELF build-id from any plugin-compiled native libs so a random id can't sneak in. Most plugins ship prebuilt `.so` files and are unaffected.

**`play` flavor → `store` flavor**
- Renamed across `android/app/build.gradle`, `lib/distribution.dart`, `lib/services/update_service.dart`, `lib/ui/views/home/settings/settings_page.dart`, `lib/ui/views/main_page.dart`. The flavor name no longer implies Google Play exclusively — the same artifact will be used for Play, IzzyOnDroid, and F-Droid Main.
- New `android/app/src/store/AndroidManifest.xml` strips media/storage permissions declared by `open_filex` (unused in this flavor) so the store listing isn't polluted with permissions we don't actually need.
- `isPlayStoreDistribution` → `isStoreDistribution`.

**Per-ABI APKs in CI (`.github/workflows/ci-release.yml`)**
- The `store` flavor now produces both an AAB (for Play) **and** `--split-per-abi` APKs (for IzzyOnDroid / direct download), uploaded to the GitHub release alongside the existing universal `mona-*.apk` standalone build.
- Released assets: `mona-<version>.apk` (standalone, universal) + `mona-store-<abi>.apk` (one per ABI).

**Updater (`lib/services/update_service.dart`)**
- Skips any release asset whose name contains `store` so sideload installs of the standalone flavor don't pick up a per-ABI store APK they can't self-install.
- Dropped the device-ABI matching path (and the `device_info_plus` dependency it needed) — the standalone APK is universal, so there's nothing to match against anymore.

**Release flow (`.github/workflows/ci-release.yml`)**
- Switched the trigger from "push tag `v*.*.*`" to `workflow_dispatch` with a `version` input. CI validates the version, bumps `pubspec.yaml` and `MARKETING_VERSION`, commits to `main`, then creates the `vX.Y.Z` tag **on the bumped commit** and pushes both atomically. Build jobs check out the tag rather than `main`, so the artifact's version code matches the tag.
- Added `flutter clean` before each `flutter build` invocation in CI to keep release output independent of any prior incremental state.
- Release notes are now auto-generated by `softprops/action-gh-release`.

### Type of change

- Maintenance
- This change requires a documentation update _(README/install instructions will need a follow-up once the IzzyOnDroid listing is live)_

### Out of scope / follow-ups

- Reproducible build verification by IzzyOnDroid — covered once they ingest the next release.
- Fastlane metadata structure (#83) and F-Droid Main listing (#195) are separate tracks.

