### PR TITLE
fix: dedupe notifications across concurrent regenerateAll runs

### DIFF
--- a/lib/controllers/notification_scheduler.dart
+++ b/lib/controllers/notification_scheduler.dart
@@ -6,6 +6,10 @@ import 'package:mona/l10n/app_localizations.dart';
 import 'package:mona/services/notification_service.dart';
 import 'package:mona/services/preferences_service.dart';
 
+int _notificationIdFor(int scheduleId, DateTime dateTime) {
+  return Object.hash(scheduleId, dateTime.millisecondsSinceEpoch) & 0x7fffffff;
+}
+
 class NotificationScheduler {
   static const int _numberOfDays = 5;
 
@@ -52,6 +56,7 @@ class NotificationScheduler {
         final includeTime = entry.includeTime;
 
         return NotificationService().scheduleNotification(
+          id: _notificationIdFor(schedule.id, dateTime),
           title: l10n.notificationMedicationReminderTitle(schedule.name),
           body: l10n.notificationMedicationReminderBody(
             includeTime

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -133,7 +133,7 @@ class NotificationService {
   }
 
   Future<void> scheduleNotification({
-    int? id,
+    required int id,
     required String title,
     required String body,
     required int year,
@@ -142,8 +142,6 @@ class NotificationService {
     required int hour,
     required int minute,
   }) async {
-    id ??= Random().nextInt(1 << 31);
-
     final scheduledDate =
         tz.TZDateTime(tz.local, year, month, day, hour, minute);
 

--- a/test/controllers/notification_scheduler_test.dart
+++ b/test/controllers/notification_scheduler_test.dart
@@ -353,4 +353,57 @@ void main() {
           .called(1);
     });
   });
+
+  group('notification ids', () {
+    List<int> capturedScheduledIds() => verify(plugin.zonedSchedule(
+          id: captureAnyNamed('id'),
+          title: anyNamed('title'),
+          body: anyNamed('body'),
+          scheduledDate: anyNamed('scheduledDate'),
+          notificationDetails: anyNamed('notificationDetails'),
+          androidScheduleMode: anyNamed('androidScheduleMode'),
+          payload: anyNamed('payload'),
+        )).captured.cast<int>();
+
+    test(
+        'the same (schedule, occurrence) pair yields the same id across regenerations',
+        () async {
+      final s = schedule(id: 7);
+      final occurrences3Days = [
+        occurrence(
+            schedule: s, date: Date.today().add(const Duration(days: 1))),
+        occurrence(
+            schedule: s, date: Date.today().add(const Duration(days: 2))),
+        occurrence(
+            schedule: s, date: Date.today().add(const Duration(days: 3))),
+      ];
+      when(occurrences.upcoming(days: 5)).thenReturn(occurrences3Days);
+      final sut = NotificationScheduler(occurrences, preferences);
+
+      await sut.regenerateAll(l10n, l10n.localeName);
+      await sut.regenerateAll(l10n, l10n.localeName);
+
+      final ids = capturedScheduledIds();
+      expect(ids.sublist(0, 3), equals(ids.sublist(3, 6)));
+    });
+
+    test('distinct (schedule, occurrence) pairs yield distinct ids', () async {
+      final a = schedule(id: 1, name: 'A');
+      final b = schedule(id: 2, name: 'B');
+      when(occurrences.upcoming(days: 5)).thenReturn([
+        occurrence(
+            schedule: a, date: Date.today().add(const Duration(days: 1))),
+        occurrence(
+            schedule: a, date: Date.today().add(const Duration(days: 2))),
+        occurrence(
+            schedule: b, date: Date.today().add(const Duration(days: 1))),
+      ]);
+      final sut = NotificationScheduler(occurrences, preferences);
+
+      await sut.regenerateAll(l10n, l10n.localeName);
+
+      final ids = capturedScheduledIds();
+      expect(ids[0], isNot(equals(ids[1])));
+    });
+  });
 }

--- a/test/services/notification_service_test.dart
+++ b/test/services/notification_service_test.dart
@@ -134,6 +134,7 @@ void main() {
 
   test('scheduleNotification adds a notification', () async {
     await service.scheduleNotification(
+        id: 1,
         title: 'Test',
         body: 'Body',
         year: 2026,
@@ -144,6 +145,7 @@ void main() {
 
     expect(fakePlugin.scheduled.length, 1);
     final n = fakePlugin.scheduled.first;
+    expect(n['id'], 1);
     expect(n['title'], 'Test');
     expect(n['body'], 'Body');
     expect((n['date'] as tz.TZDateTime).hour, 10);
@@ -160,6 +162,7 @@ void main() {
 
   test('cancelAllNotifications clears scheduled', () async {
     await service.scheduleNotification(
+        id: 1,
         title: 'T1',
         body: 'B1',
         year: 2026,
@@ -173,6 +176,7 @@ void main() {
 
   test('cancelPendingNotifications removes only pending', () async {
     await service.scheduleNotification(
+        id: 1,
         title: 'T1',
         body: 'B1',
         year: 2026,
@@ -181,6 +185,7 @@ void main() {
         hour: 10,
         minute: 0);
     await service.scheduleNotification(
+        id: 2,
         title: 'T2',
         body: 'B2',
         year: 2026,


### PR DESCRIPTION
### Description

Fixes occasional duplicate medication reminders firing at the same minute for a single scheduled occurrence.

**Root cause.** `NotificationService.scheduleNotification` assigned a fresh random id on every call. `flutter_local_notifications.zonedSchedule` dedupes by id, so two overlapping `NotificationScheduler.regenerateAll` runs (triggered when more than one of the three observed providers notifies in the same frame) would race: the second run could `cancel` only the subset the first had registered so far, then re-register the full set under brand-new random ids. End state: leftovers from run A plus a full set from run B, hence duplicates.

**Fix.** Derive a stable notification id from `(scheduleId, dateTime)`:

```dart
int _notificationIdFor(int scheduleId, DateTime dateTime) {
  return Object.hash(scheduleId, dateTime.millisecondsSinceEpoch) & 0x7fffffff;
}
```

`scheduleNotification`'s `id` is now `required`. The ad-hoc `showNotification` keeps its random fallback (it's not tied to a recurring occurrence).

### Type of change
- Bug fix (non-breaking change which fixes an issue)