### PR TITLE
build: rework flake.nix, was missing deps and nix-ld setup

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -19,6 +19,8 @@ We use a standard **Fork and Pull Request** workflow. To keep our main branch st
 
 ### 2. Set Up the Environment
 
+**Linux / macOS**
+
 We have provided a script to automatically set up FVM, configure your shell, and fetch the necessary dependencies.
 
 ```bash
@@ -26,13 +28,20 @@ chmod +x scripts/setup_dev.sh
 ./scripts/setup_dev.sh
 ```
 
-Windows users :
+> [!NOTE]
+> After running the script, you may need to restart your terminal or run `source ~/.bashrc` (or `~/.zshrc`) to use the FVM commands.
+
+**NixOS**
+
+The repo ships a `flake.nix` with a ready-made dev shell. The only system-level requirement is `programs.nix-ld.enable = true` in your NixOS configuration, which lets FVM's pre-built Dart binaries run.
+
+Enter the shell with `nix develop` (or `direnv allow` if you use direnv), then `fvm flutter run` works as usual.
+
+**Windows**
+
 ```powershell
 ./scripts/setup_dev.ps1
 ```
-
-> [!NOTE]
-> After running the script, you may need to restart your terminal or run `source ~/.bashrc` (or `~/.zshrc`) to use the FVM commands.
 
 ### 3. Create a Feature Branch
 

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ android/build/
 
 # Code coverage
 coverage/
+
+# Nix/direnv
+.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -25,16 +25,11 @@
       pkgs.mkShell {
         packages = with pkgs; [
           pkg-config fvm clang cmake ninja
-          # GTK stack — in packages so nixpkgs pkg-config wrapper auto-discovers .pc files
           gtk3 glib cairo pango gdk-pixbuf libepoxy fontconfig dbus
           at-spi2-core libsysprof-capture pcre2 libffi
-          # Image libs (gdk-pixbuf/libtiff transitive)
           libtiff libdeflate lerc libjpeg libpng libwebp jbigkit xz zstd
-          # System (gio/dbus chain)
           util-linux libselinux libsepol zlib systemd expat
-          # Text rendering (pango chain)
           libthai libdatrie harfbuzz fribidi
-          # X11
           libx11 libxcursor libxrandr libxi libxdmcp libxau libxcb libxkbcommon
         ];
 
@@ -42,11 +37,12 @@
         NIX_LD_LIBRARY_PATH = lib.makeLibraryPath ([pkgs.stdenv.cc.cc] ++ runtimeLibs);
         LD_LIBRARY_PATH = lib.makeLibraryPath runtimeLibs;
 
-        LDFLAGS = "-Wl,--allow-shlib-undefined " + lib.concatMapStringsSep " " (p: "-L${p}/lib") (with pkgs; [
-          libepoxy fontconfig.lib gtk3 glib.out pango.out cairo gdk-pixbuf
-          libselinux.out libsepol.out libthai libdatrie.out harfbuzz fribidi
-          libxdmcp libxau libxcb
-        ]);
+        LDFLAGS = "-Wl,-rpath-link," + lib.makeLibraryPath runtimeLibs + " "
+          + lib.concatMapStringsSep " " (p: "-L${p}/lib") (with pkgs; [
+            libepoxy fontconfig.lib gtk3 glib.out pango.out cairo gdk-pixbuf
+            libselinux.out libsepol.out libthai libdatrie.out harfbuzz fribidi
+            libxdmcp libxau libxcb
+          ]);
       };
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -5,53 +5,48 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
 
-  outputs =
-    { self, nixpkgs }:
-    {
-      devShells.x86_64-linux.default =
-        let
-          pkgs = import nixpkgs { system = "x86_64-linux"; };
-        in
-        pkgs.mkShell {
-          packages = with pkgs; [
-            pkg-config
-            gtk3
-            glib
-            gdk-pixbuf
-            sysprof
-            libepoxy
-            fontconfig
-            libsysprof-capture
-            clang
-            pcre2
-            zlib
-            ninja
-            libX11
-            libXcursor
-            libXrandr
-            libXi
-            cairo
-            pango
-          ];
-          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
-            pkgs.libepoxy
-            pkgs.fontconfig
-            pkgs.gtk3
-            pkgs.glib
-            pkgs.pango
-            pkgs.cairo
-            pkgs.gdk-pixbuf
-          ];
+  outputs = {
+    self,
+    nixpkgs,
+  }: {
+    devShells.x86_64-linux.default = let
+      pkgs = import nixpkgs {system = "x86_64-linux";};
+      lib = pkgs.lib;
 
-          PKG_CONFIG_PATH = pkgs.lib.makeSearchPath "lib/pkgconfig" [
-            pkgs.gtk3
-            pkgs.glib
-            pkgs.fontconfig
-            pkgs.libsysprof-capture
-            pkgs.libepoxy
-            pkgs.sysprof
-            pkgs.gdk-pixbuf
-          ];
-        };
-    };
+      runtimeLibs = with pkgs; [
+        libepoxy fontconfig.lib
+        gtk3 glib.out pango.out cairo gdk-pixbuf atk
+        libselinux.out libsepol.out
+        libthai libdatrie.out harfbuzz fribidi zlib
+        libx11 libxcursor libxrandr libxi libxdmcp libxau libxcb
+        libxkbcommon dbus systemd
+      ];
+    in
+      pkgs.mkShell {
+        packages = with pkgs; [
+          pkg-config fvm clang cmake ninja
+          # GTK stack — in packages so nixpkgs pkg-config wrapper auto-discovers .pc files
+          gtk3 glib cairo pango gdk-pixbuf libepoxy fontconfig dbus
+          at-spi2-core libsysprof-capture pcre2 libffi
+          # Image libs (gdk-pixbuf/libtiff transitive)
+          libtiff libdeflate lerc libjpeg libpng libwebp jbigkit xz zstd
+          # System (gio/dbus chain)
+          util-linux libselinux libsepol zlib systemd expat
+          # Text rendering (pango chain)
+          libthai libdatrie harfbuzz fribidi
+          # X11
+          libx11 libxcursor libxrandr libxi libxdmcp libxau libxcb libxkbcommon
+        ];
+
+        NIX_LD = lib.fileContents "${pkgs.stdenv.cc}/nix-support/dynamic-linker";
+        NIX_LD_LIBRARY_PATH = lib.makeLibraryPath ([pkgs.stdenv.cc.cc] ++ runtimeLibs);
+        LD_LIBRARY_PATH = lib.makeLibraryPath runtimeLibs;
+
+        LDFLAGS = "-Wl,--allow-shlib-undefined " + lib.concatMapStringsSep " " (p: "-L${p}/lib") (with pkgs; [
+          libepoxy fontconfig.lib gtk3 glib.out pango.out cairo gdk-pixbuf
+          libselinux.out libsepol.out libthai libdatrie.out harfbuzz fribidi
+          libxdmcp libxau libxcb
+        ]);
+      };
+  };
 }


### PR DESCRIPTION
### Description

The devshell wasn't working on NixOS. A few things were wrong:

- `cmake` and `fvm` weren't in the packages
- `NIX_LD` and `NIX_LD_LIBRARY_PATH` were missing. Without these, nix-ld can't run FVM's pre-built Dart binaries
- `LD_LIBRARY_PATH` existed but was missing most of the GTK/X11 chain so the app crashed at runtime
- `PKG_CONFIG_PATH` was set manually which bypasses the nixpkgs wrapper, libs need to be in `packages` instead
- Some package names were wrong (`libX11` vs `libx11`) and a bunch of transitive deps were missing (`at-spi2-core`, `libselinux`, `libthai`, `systemd`...)

Also added `.envrc` for direnv and gitignored `.direnv/`.

Related to issue(s): #

### Type of change

- Maintenance