### PR TITLE
feat(android): remove INTERNET permission from store builds

### DIFF
--- a/android/app/src/store/AndroidManifest.xml
+++ b/android/app/src/store/AndroidManifest.xml
@@ -13,4 +13,8 @@
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
         tools:node="remove" />
+    <!-- Only used by UpdateService, build type manifests re-add it for hot reload. -->
+    <uses-permission
+        android:name="android.permission.INTERNET"
+        tools:node="remove" />
 </manifest>


### PR DESCRIPTION
### Description
INTERNET not needed as the self-updater is disabled

Related to issue(s): #211 

### Type of change
- Maintenance