### PR TITLE
fix(devcontainer): desktop linux run support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,12 +16,25 @@
     "features": {
         "ghcr.io/devcontainers/features/common-utils:2": {
             "configureZshAsDefaultShell": true,
+            "upgradePackages": "true",
             "installZsh": true
         },
         "ghcr.io/devcontainers/features/git:1": {}
     },
-    "user": "vscode",
     "onCreateCommand": {
-        "take ownership": "sudo chown vscode:vscode /opt -Rc"
-    }
+        "take ownership of android sdk": "sudo chown vscode:vscode /opt -Rc",
+        "install flutter and dependencies": "fvm install && fvm flutter pub get",
+        "setup build prefix": "mkdir -p ${containerWorkspaceFolder}/build/prefix"
+    },
+    "containerEnv": {
+        "PREFIX": "${containerWorkspaceFolder}/build/prefix",
+        "WAYLAND_DISPLAY": "${localEnv:WAYLAND_DISPLAY}",
+        "XDG_RUNTIME_DIR": "${localEnv:XDG_RUNTIME_DIR}",
+        "XDG_SESSION_TYPE": "${localEnv:XDG_SESSION_TYPE}",
+        "DBUS_SYSTEM_BUS_ADDRESS": "unix:path=/var/run/dbus/system_bus_socket"
+    },
+    "mounts": [
+        "source=${localEnv:XDG_RUNTIME_DIR},target=${localEnv:XDG_RUNTIME_DIR},type=bind,consistency=cached",
+        "source=/var/run/dbus/system_bus_socket,target=/var/run/dbus/system_bus_socket,type=bind,consistency=cached"
+    ]
 }

--- a/Containerfile
+++ b/Containerfile
@@ -42,11 +42,16 @@ RUN /out/fvm --version
 
 FROM docker.io/library/fedora:latest AS development
 
-# install OpenJDK, CMake; Copy FVM and the SDK.
+# Install Android-specific dependencies.
 RUN dnf in java-25-openjdk-devel java-25-openjdk java-25-openjdk-src \
     --assumeyes
-COPY --from=fvm /out/fvm /usr/bin/fvm
 COPY --from=docker.io/runmymind/docker-android-sdk:latest \
     /opt/android-sdk-linux /opt/android-sdk-linux
 ENV ANDROID_HOME=/opt/android-sdk-linux
+
+# Install Linux-specific dependencies.
+RUN dnf in cmake clang ninja gtk3-devel glib2-devel --assumeyes
+
+# Finalise.
+COPY --from=fvm /out/fvm /usr/bin/fvm
 USER vscode


### PR DESCRIPTION

### Description
This PR adds the software necessary to build the Linux version of Mona, as well as setting up the environment variables and mounts to pass-thru the Wayland socket of the host to the development container; the reason for doing that is to make it easier for new people to develop and contribute to Mona.

Additionally, there was a *slight* refactor of the Containerfile.

### Type of change
- Bug fix (non-breaking change which fixes an issue)
- Maintenance

### Acknowledgments
This commit was coauthored together with @Frozzie89 on a Discord call, additionally she was the one who has brought that issue up to my attention.
