### PR TITLE
Add Patrol E2E tests for medication schedules (Android + CI)

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "version": "2.5.9",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a",
+      "integrity": "sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a"
+    },
+    "ghcr.io/devcontainers/features/git:1": {
+      "version": "1.3.5",
+      "resolved": "ghcr.io/devcontainers/features/git@sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251",
+      "integrity": "sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,6 +34,9 @@
         "XDG_SESSION_TYPE": "${localEnv:XDG_SESSION_TYPE}",
         "DBUS_SYSTEM_BUS_ADDRESS": "unix:path=/var/run/dbus/system_bus_socket"
     },
+    "remoteEnv": {
+        "PATH": "${containerEnv:HOME}/fvm/default/bin:${containerEnv:HOME}/.pub-cache/bin:${containerEnv:ANDROID_HOME}/platform-tools:${containerEnv:PATH}"
+    },
     "mounts": [
         "source=${localEnv:XDG_RUNTIME_DIR},target=${localEnv:XDG_RUNTIME_DIR},type=bind,consistency=cached",
         "source=/var/run/dbus/system_bus_socket,target=/var/run/dbus/system_bus_socket,type=bind,consistency=cached"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,6 +21,7 @@
         },
         "ghcr.io/devcontainers/features/git:1": {}
     },
+    "runArgs": ["--add-host=host.docker.internal:host-gateway"],
     "onCreateCommand": {
         "take ownership of android sdk": "sudo chown vscode:vscode /opt -Rc",
         "install flutter and dependencies": "fvm install && fvm flutter pub get",

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -1,4 +1,4 @@
-name: CI - E2E/Patrol Android
+name: CI - E2E
 
 # Patrol drives the real app on an Android emulator. Patrol has no Linux-desktop
 # support, so these tests cannot run on a plain runner — they need the

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -1,0 +1,67 @@
+name: CI - E2E (Patrol Android)
+
+# Patrol drives the real app on an Android emulator. Patrol has no Linux-desktop
+# support, so these tests cannot run on a plain runner — they need the
+# KVM-accelerated emulator from reactivecircus/android-emulator-runner. This job
+# is intentionally separate from ci-pr.yml because the emulator makes it slow.
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  e2e_android:
+    name: Patrol schedules E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version-file: .fvmrc
+          cache: true
+
+      - name: Get dependencies
+        run: flutter pub get
+
+      - name: Install Patrol CLI
+        run: |
+          dart pub global activate patrol_cli
+          echo "$HOME/.pub-cache/bin" >> "$GITHUB_PATH"
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      # The app builds debug with applicationIdSuffix ".dev" (see
+      # android/app/build.gradle), so the installed package under test is
+      # com.deliacheminot.mona.dev. If Patrol reports it cannot find the app,
+      # set patrol.android.package_name in pubspec.yaml to that suffixed id.
+      - name: Run Patrol tests on emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          target: google_apis
+          arch: x86_64
+          profile: pixel_6
+          ram-size: 4096M
+          disable-animations: true
+          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
+          script: patrol test --flavor standalone --target integration_test/schedules_test.dart
+
+      - name: Upload Patrol results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: patrol-results
+          path: |
+            build/app/outputs/androidTest-results/
+            build/app/reports/
+          if-no-files-found: ignore

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -53,7 +53,7 @@ jobs:
           ram-size: 4096M
           disable-animations: true
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
-          script: dart run patrol_cli:main test --flavor standalone
+          script: dart run patrol_cli:main test --flavor standalone --verbose
 
       - name: Upload Patrol results
         if: always()

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -1,4 +1,4 @@
-name: CI - E2E (Patrol Android)
+name: CI - E2E/Patrol Android
 
 # Patrol drives the real app on an Android emulator. Patrol has no Linux-desktop
 # support, so these tests cannot run on a plain runner — they need the
@@ -10,7 +10,7 @@ on:
 
 jobs:
   e2e_android:
-    name: Patrol E2E
+    name: Patrol Android
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   e2e_android:
-    name: Patrol schedules E2E
+    name: Patrol E2E
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -26,12 +26,10 @@ jobs:
           cache: true
 
       - name: Get dependencies
+        # Installs the Patrol framework AND the Patrol CLI: patrol_cli is a
+        # dev_dependency (pinned in pubspec.lock), so there is no separate
+        # `dart pub global activate`. The CLI is run as `dart run patrol_cli:main`.
         run: flutter pub get
-
-      - name: Install Patrol CLI
-        run: |
-          dart pub global activate patrol_cli
-          echo "$HOME/.pub-cache/bin" >> "$GITHUB_PATH"
 
       - name: Enable KVM
         run: |
@@ -42,8 +40,9 @@ jobs:
 
       # The app builds debug with applicationIdSuffix ".dev" (see
       # android/app/build.gradle), so the installed package under test is
-      # com.deliacheminot.mona.dev. If Patrol reports it cannot find the app,
-      # set patrol.android.package_name in pubspec.yaml to that suffixed id.
+      # com.deliacheminot.mona.dev — already set as patrol.android.package_name
+      # in pubspec.yaml. Omitting --target runs every *_test.dart under
+      # integration_test/ (the test_directory in pubspec.yaml).
       - name: Run Patrol tests on emulator
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -54,7 +53,7 @@ jobs:
           ram-size: 4096M
           disable-animations: true
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
-          script: patrol test --flavor standalone --target integration_test/schedules_test.dart
+          script: dart run patrol_cli:main test --flavor standalone
 
       - name: Upload Patrol results
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ coverage/
 
 # Nix/direnv
 .direnv/
+# Patrol E2E: generated test bundle (regenerated on every `patrol test`/`build`)
+integration_test/test_bundle.dart

--- a/Containerfile
+++ b/Containerfile
@@ -55,12 +55,6 @@ RUN dnf in cmake clang ninja gtk3-devel glib2-devel --assumeyes
 
 # Finalise.
 COPY --from=fvm /out/fvm /usr/bin/fvm
-# Put the Patrol E2E toolchain on PATH for every shell (login/non-login) and for
-# `exec`/CI, not just the interactive terminal:
-#   - $HOME/fvm/default/bin        -> fvm-pinned `flutter`/`dart` (created by `fvm install`)
-#   - $HOME/.pub-cache/bin         -> binaries from any `dart pub global activate`
-#   - $ANDROID_HOME/platform-tools -> `adb`, used to reach a host emulator over TCP
-# The Patrol CLI is a dev_dependency (see pubspec.yaml), invoked as
-# `fvm dart run patrol_cli:main ...` — it does not need to be on PATH.
+# Put the Patrol E2E toolchain on PATH for every shell (login/non-login) 
 ENV PATH="/home/vscode/fvm/default/bin:/home/vscode/.pub-cache/bin:${ANDROID_HOME}/platform-tools:${PATH}"
 USER vscode

--- a/Containerfile
+++ b/Containerfile
@@ -48,10 +48,19 @@ RUN dnf in java-25-openjdk-devel java-25-openjdk java-25-openjdk-src \
 COPY --from=docker.io/runmymind/docker-android-sdk:latest \
     /opt/android-sdk-linux /opt/android-sdk-linux
 ENV ANDROID_HOME=/opt/android-sdk-linux
+ENV ANDROID_SDK_ROOT=/opt/android-sdk-linux
 
 # Install Linux-specific dependencies.
 RUN dnf in cmake clang ninja gtk3-devel glib2-devel --assumeyes
 
 # Finalise.
 COPY --from=fvm /out/fvm /usr/bin/fvm
+# Put the Patrol E2E toolchain on PATH for every shell (login/non-login) and for
+# `exec`/CI, not just the interactive terminal:
+#   - $HOME/fvm/default/bin        -> fvm-pinned `flutter`/`dart` (created by `fvm install`)
+#   - $HOME/.pub-cache/bin         -> binaries from any `dart pub global activate`
+#   - $ANDROID_HOME/platform-tools -> `adb`, used to reach a host emulator over TCP
+# The Patrol CLI is a dev_dependency (see pubspec.yaml), invoked as
+# `fvm dart run patrol_cli:main ...` — it does not need to be on PATH.
+ENV PATH="/home/vscode/fvm/default/bin:/home/vscode/.pub-cache/bin:${ANDROID_HOME}/platform-tools:${PATH}"
 USER vscode

--- a/Containerfile
+++ b/Containerfile
@@ -55,6 +55,4 @@ RUN dnf in cmake clang ninja gtk3-devel glib2-devel --assumeyes
 
 # Finalise.
 COPY --from=fvm /out/fvm /usr/bin/fvm
-# Put the Patrol E2E toolchain on PATH for every shell (login/non-login) 
-ENV PATH="/home/vscode/fvm/default/bin:/home/vscode/.pub-cache/bin:${ANDROID_HOME}/platform-tools:${PATH}"
 USER vscode

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -57,12 +57,20 @@ android {
         jvmTarget = "17"
     }
 
+    // Patrol E2E: required for `clearPackageData` between Dart tests.
+    testOptions {
+        execution "ANDROIDX_TEST_ORCHESTRATOR"
+    }
+
     defaultConfig {
         applicationId = "com.deliacheminot.mona"
         minSdkVersion flutter.minSdkVersion
         targetSdkVersion flutter.targetSdkVersion
         versionCode = flutterVersionCode.toInteger()
         versionName = flutterVersionName
+        // Patrol E2E: run instrumented Dart tests via the Patrol JUnit runner.
+        testInstrumentationRunner "pl.leancode.patrol.PatrolJUnitRunner"
+        testInstrumentationRunnerArguments clearPackageData: "true"
         // Empty list disables generating density-specific PNGs from vector
         // drawables at build time (nondeterministic across machines).
         vectorDrawables.generatedDensities = []
@@ -121,4 +129,6 @@ flutter {
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
+    // Patrol E2E: test orchestrator enables clearPackageData between tests.
+    androidTestUtil("androidx.test:orchestrator:1.5.1")
 }

--- a/android/app/src/androidTest/java/com/deliacheminot/mona/MainActivityTest.java
+++ b/android/app/src/androidTest/java/com/deliacheminot/mona/MainActivityTest.java
@@ -1,0 +1,31 @@
+package com.deliacheminot.mona;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import pl.leancode.patrol.PatrolJUnitRunner;
+
+@RunWith(Parameterized.class)
+public class MainActivityTest {
+    @Parameters(name = "{0}")
+    public static Object[] testCases() {
+        PatrolJUnitRunner instrumentation = (PatrolJUnitRunner) InstrumentationRegistry.getInstrumentation();
+        instrumentation.setUp(MainActivity.class);
+        instrumentation.waitForPatrolAppService();
+        return instrumentation.listDartTests();
+    }
+
+    public MainActivityTest(String dartTestName) {
+        this.dartTestName = dartTestName;
+    }
+
+    private final String dartTestName;
+
+    @Test
+    public void runDartTest() {
+        PatrolJUnitRunner instrumentation = (PatrolJUnitRunner) InstrumentationRegistry.getInstrumentation();
+        instrumentation.runDartTest(dartTestName);
+    }
+}

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -6,27 +6,35 @@ the way a user would.
 
 ## Important: where these can run
 
-Patrol's native automation supports **Android, iOS, macOS** - **not Linux
-desktop**. The dev container only has a Linux desktop target and no
-KVM/emulator, so these tests **cannot run inside the container**. Run them on:
+Patrol's native automation needs an **Android, iOS, or macOS** target - **not
+Linux desktop**. The dev container has no KVM, so it **cannot host its own
+emulator**. It can, however, drive a device/emulator that is reachable over
+ADB - including one running on your **host** machine (see
+[Running from the dev container](#running-from-the-dev-container) below). So the
+options are:
 
+- the dev container, attached to a host emulator/device over ADB, or
 - a local machine with an Android emulator or a physical device, or
 - CI - see [.github/workflows/ci-e2e.yml](../.github/workflows/ci-e2e.yml),
   which boots a KVM-accelerated emulator via `android-emulator-runner`.
 
-What *can* be verified in the container is that everything compiles, including
+Even with no device, the container can verify everything compiles, including
 the instrumentation APK:
 
 ```bash
-patrol build android --flavor standalone
+fvm dart run patrol_cli:main build android --flavor standalone
 ```
 
 ## One-time setup
 
-1. `fvm flutter pub get` (Patrol config lives in `pubspec.yaml` under `patrol:`).
-2. Install the CLI: `fvm dart pub global activate patrol_cli` and make sure
-   `~/.pub-cache/bin` is on your `PATH`.
-3. `patrol doctor` to check your toolchain.
+1. `fvm flutter pub get`. This installs both the Patrol framework and the Patrol
+   CLI - `patrol_cli` is a `dev_dependency` in `pubspec.yaml` (pinned in
+   `pubspec.lock`), so there is **no** separate `dart pub global activate` step.
+   Patrol config lives in `pubspec.yaml` under `patrol:`.
+2. The CLI is invoked as `fvm dart run patrol_cli:main ...` (the `:main` is
+   patrol_cli's `bin/main.dart`). In the dev container, step 1 runs
+   automatically on create.
+3. `fvm dart run patrol_cli:main doctor` to check your toolchain.
 
 Native wiring already done in this branch:
 
@@ -38,12 +46,30 @@ Native wiring already done in this branch:
 ## Running
 
 ```bash
-# All E2E tests on a running emulator/device (note the flavor - the app
-# defines store/standalone flavors, so a flavor is required):
-patrol test --flavor standalone
+# All E2E tests on a connected emulator/device (note the flavor - the app
+# defines store/standalone flavors, so a flavor is required). Omitting --target
+# auto-discovers every *_test.dart under integration_test/:
+fvm dart run patrol_cli:main test --flavor standalone
 
 # A single file:
-patrol test --flavor standalone --target integration_test/schedules_test.dart
+fvm dart run patrol_cli:main test --flavor standalone \
+  --target integration_test/schedules_test.dart
+```
+
+### Running from the dev container
+
+The container can't host an emulator, but it can attach to one running on your
+**host** over ADB. `devcontainer.json` adds
+`--add-host=host.docker.internal:host-gateway` so the host is resolvable.
+
+```bash
+# On the HOST, with an emulator or device running:
+adb tcpip 5555            # switch the device to TCP/IP mode
+
+# Inside the dev container:
+adb connect host.docker.internal:5555
+adb devices               # confirm the device is listed
+fvm dart run patrol_cli:main test --flavor standalone
 ```
 
 ### Flavors and the `.dev` suffix
@@ -70,7 +96,7 @@ can't be made or verified from this Linux container. To add iOS later:
 
 1. Add a `RunnerTests` target / Patrol test bundle in `ios/Runner.xcodeproj`.
 2. Confirm `patrol.ios.bundle_id` in `pubspec.yaml` matches the app's bundle id.
-3. Run `patrol test --target integration_test/schedules_test.dart` on a Simulator
-   from macOS.
+3. Run `fvm dart run patrol_cli:main test --target integration_test/schedules_test.dart`
+   on a Simulator from macOS.
 
 See the [Patrol iOS setup docs](https://patrol.leancode.co/documentation).

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -80,14 +80,6 @@ Debug builds append `applicationIdSuffix ".dev"`
 `com.deliacheminot.mona`. `pubspec.yaml` sets `patrol.android.package_name` to
 the `.dev` id to match, so Patrol only ever manages the test build.
 
-> **Do not point `package_name` at the base id `com.deliacheminot.mona`.**
-> Patrol uninstalls/reinstalls that package, and `clearPackageData` (enabled in
-> `build.gradle` for test isolation) runs `pm clear` on it between tests - so
-> targeting the base id would **erase a production Mona install and all its
-> data**. Even with the `.dev` split, prefer running E2E on a dedicated
-> emulator or throwaway device rather than a phone holding real data: a debug
-> (`flutter run`) install of the app *also* lives at `.dev` and would be wiped.
-
 ## Writing tests - notes for this app
 
 The schedules UI defines **no widget `Key`s**, so tests target widgets by their

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -2,25 +2,23 @@
 
 End-to-end UI tests for Mona, written with [Patrol](https://patrol.leancode.co)
 on top of Flutter's `integration_test`. They launch the real app and drive it
-the way a user would. The first suite covers **Medication Schedules**
-([schedules_test.dart](schedules_test.dart)): empty state, creating interval and
-daily schedules, editing a name, and deleting with confirmation.
+the way a user would.
 
 ## Important: where these can run
 
-Patrol's native automation supports **Android, iOS, macOS** — **not Linux
+Patrol's native automation supports **Android, iOS, macOS** - **not Linux
 desktop**. The dev container only has a Linux desktop target and no
 KVM/emulator, so these tests **cannot run inside the container**. Run them on:
 
 - a local machine with an Android emulator or a physical device, or
-- CI — see [.github/workflows/ci-e2e.yml](../.github/workflows/ci-e2e.yml),
+- CI - see [.github/workflows/ci-e2e.yml](../.github/workflows/ci-e2e.yml),
   which boots a KVM-accelerated emulator via `android-emulator-runner`.
 
 What *can* be verified in the container is that everything compiles, including
 the instrumentation APK:
 
 ```bash
-patrol build android --flavor standalone --target integration_test/schedules_test.dart
+patrol build android --flavor standalone
 ```
 
 ## One-time setup
@@ -32,15 +30,15 @@ patrol build android --flavor standalone --target integration_test/schedules_tes
 
 Native wiring already done in this branch:
 
-- `android/app/build.gradle` — `PatrolJUnitRunner` test runner, the
+- `android/app/build.gradle` - `PatrolJUnitRunner` test runner, the
   `ANDROIDX_TEST_ORCHESTRATOR` test option, and the `orchestrator` dependency.
 - `android/app/src/androidTest/java/com/deliacheminot/mona/MainActivityTest.java`
-  — the JUnit entrypoint Patrol uses to enumerate and run the Dart tests.
+  - the JUnit entrypoint Patrol uses to enumerate and run the Dart tests.
 
 ## Running
 
 ```bash
-# All E2E tests on a running emulator/device (note the flavor — the app
+# All E2E tests on a running emulator/device (note the flavor - the app
 # defines store/standalone flavors, so a flavor is required):
 patrol test --flavor standalone
 
@@ -56,16 +54,16 @@ Debug builds append `applicationIdSuffix ".dev"`
 to the base id `com.deliacheminot.mona`. If Patrol can't find the app under
 test, change it to `com.deliacheminot.mona.dev`.
 
-## Writing tests — notes for this app
+## Writing tests - notes for this app
 
 The schedules UI defines **no widget `Key`s**, so tests target widgets by their
 visible (English) label, e.g. `$(TextField).containing('Name')`. This is
 deliberate: when a route is pushed the previous route stays mounted, so
-index-based `TextField` finders are ambiguous across the navigation stack —
+index-based `TextField` finders are ambiguous across the navigation stack -
 prefer label-scoped finders. If the UI strings change, update the `const`
 labels at the top of the test file.
 
-## iOS (follow-up — not yet wired)
+## iOS (follow-up - not yet wired)
 
 The chosen target is Android-in-CI, and iOS requires Xcode project changes that
 can't be made or verified from this Linux container. To add iOS later:

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -1,0 +1,78 @@
+# E2E tests (Patrol)
+
+End-to-end UI tests for Mona, written with [Patrol](https://patrol.leancode.co)
+on top of Flutter's `integration_test`. They launch the real app and drive it
+the way a user would. The first suite covers **Medication Schedules**
+([schedules_test.dart](schedules_test.dart)): empty state, creating interval and
+daily schedules, editing a name, and deleting with confirmation.
+
+## Important: where these can run
+
+Patrol's native automation supports **Android, iOS, macOS** — **not Linux
+desktop**. The dev container only has a Linux desktop target and no
+KVM/emulator, so these tests **cannot run inside the container**. Run them on:
+
+- a local machine with an Android emulator or a physical device, or
+- CI — see [.github/workflows/ci-e2e.yml](../.github/workflows/ci-e2e.yml),
+  which boots a KVM-accelerated emulator via `android-emulator-runner`.
+
+What *can* be verified in the container is that everything compiles, including
+the instrumentation APK:
+
+```bash
+patrol build android --flavor standalone --target integration_test/schedules_test.dart
+```
+
+## One-time setup
+
+1. `fvm flutter pub get` (Patrol config lives in `pubspec.yaml` under `patrol:`).
+2. Install the CLI: `fvm dart pub global activate patrol_cli` and make sure
+   `~/.pub-cache/bin` is on your `PATH`.
+3. `patrol doctor` to check your toolchain.
+
+Native wiring already done in this branch:
+
+- `android/app/build.gradle` — `PatrolJUnitRunner` test runner, the
+  `ANDROIDX_TEST_ORCHESTRATOR` test option, and the `orchestrator` dependency.
+- `android/app/src/androidTest/java/com/deliacheminot/mona/MainActivityTest.java`
+  — the JUnit entrypoint Patrol uses to enumerate and run the Dart tests.
+
+## Running
+
+```bash
+# All E2E tests on a running emulator/device (note the flavor — the app
+# defines store/standalone flavors, so a flavor is required):
+patrol test --flavor standalone
+
+# A single file:
+patrol test --flavor standalone --target integration_test/schedules_test.dart
+```
+
+### Flavors and the `.dev` suffix
+
+Debug builds append `applicationIdSuffix ".dev"`
+(`android/app/build.gradle`), so the package installed during tests is
+`com.deliacheminot.mona.dev`. `pubspec.yaml` sets `patrol.android.package_name`
+to the base id `com.deliacheminot.mona`. If Patrol can't find the app under
+test, change it to `com.deliacheminot.mona.dev`.
+
+## Writing tests — notes for this app
+
+The schedules UI defines **no widget `Key`s**, so tests target widgets by their
+visible (English) label, e.g. `$(TextField).containing('Name')`. This is
+deliberate: when a route is pushed the previous route stays mounted, so
+index-based `TextField` finders are ambiguous across the navigation stack —
+prefer label-scoped finders. If the UI strings change, update the `const`
+labels at the top of the test file.
+
+## iOS (follow-up — not yet wired)
+
+The chosen target is Android-in-CI, and iOS requires Xcode project changes that
+can't be made or verified from this Linux container. To add iOS later:
+
+1. Add a `RunnerTests` target / Patrol test bundle in `ios/Runner.xcodeproj`.
+2. Confirm `patrol.ios.bundle_id` in `pubspec.yaml` matches the app's bundle id.
+3. Run `patrol test --target integration_test/schedules_test.dart` on a Simulator
+   from macOS.
+
+See the [Patrol iOS setup docs](https://patrol.leancode.co/documentation).

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -72,13 +72,21 @@ adb devices               # confirm the device is listed
 fvm dart run patrol_cli:main test --flavor standalone
 ```
 
-### Flavors and the `.dev` suffix
+### Flavors, the `.dev` suffix, and not wiping a real install
 
 Debug builds append `applicationIdSuffix ".dev"`
 (`android/app/build.gradle`), so the package installed during tests is
-`com.deliacheminot.mona.dev`. `pubspec.yaml` sets `patrol.android.package_name`
-to the base id `com.deliacheminot.mona`. If Patrol can't find the app under
-test, change it to `com.deliacheminot.mona.dev`.
+`com.deliacheminot.mona.dev` - deliberately separate from a released
+`com.deliacheminot.mona`. `pubspec.yaml` sets `patrol.android.package_name` to
+the `.dev` id to match, so Patrol only ever manages the test build.
+
+> **Do not point `package_name` at the base id `com.deliacheminot.mona`.**
+> Patrol uninstalls/reinstalls that package, and `clearPackageData` (enabled in
+> `build.gradle` for test isolation) runs `pm clear` on it between tests - so
+> targeting the base id would **erase a production Mona install and all its
+> data**. Even with the `.dev` split, prefer running E2E on a dedicated
+> emulator or throwaway device rather than a phone holding real data: a debug
+> (`flutter run`) install of the app *also* lives at `.dev` and would be wiped.
 
 ## Writing tests - notes for this app
 

--- a/integration_test/schedules_test.dart
+++ b/integration_test/schedules_test.dart
@@ -103,9 +103,6 @@ void main() {
     await $(_delete).tap(); // form's Delete button -> confirmation dialog
     await $(AlertDialog).$(_delete).tap(); // confirm in the dialog
 
-    await $.tester.pageBack(); // EditSchedulePage -> schedules list
-    await $.pumpAndSettle();
-
     await $(_emptyState).waitUntilVisible();
     expect($('To Delete'), findsNothing);
     expect($(_emptyState), findsOneWidget);

--- a/integration_test/schedules_test.dart
+++ b/integration_test/schedules_test.dart
@@ -33,6 +33,22 @@ const _editScheduleInfo = 'Edit schedule info';
 const _delete = 'Delete';
 
 void main() {
+  patrolTest('deletes a schedule with confirmation', ($) async {
+    await _launchApp($);
+    await _openSchedules($);
+    await _createIntervalSchedule($, name: 'To Delete');
+
+    await $(ListTile).containing('To Delete').tap();
+    await $(_editScheduleInfo).tap();
+
+    await $(_delete).tap(); // form's Delete button -> confirmation dialog
+    await $(AlertDialog).$(_delete).tap(); // confirm in the dialog
+
+    await $(_emptyState).waitUntilVisible();
+    expect($('To Delete'), findsNothing);
+    expect($(_emptyState), findsOneWidget);
+  });
+
   patrolTest('shows empty state when there are no schedules', ($) async {
     await _launchApp($);
     await _openSchedules($);
@@ -90,22 +106,6 @@ void main() {
     await $('New Name').waitUntilVisible();
     expect($('New Name'), findsOneWidget);
     expect($('Old Name'), findsNothing);
-  });
-
-  patrolTest('deletes a schedule with confirmation', ($) async {
-    await _launchApp($);
-    await _openSchedules($);
-    await _createIntervalSchedule($, name: 'To Delete');
-
-    await $(ListTile).containing('To Delete').tap();
-    await $(_editScheduleInfo).tap();
-
-    await $(_delete).tap(); // form's Delete button -> confirmation dialog
-    await $(AlertDialog).$(_delete).tap(); // confirm in the dialog
-
-    await $(_emptyState).waitUntilVisible();
-    expect($('To Delete'), findsNothing);
-    expect($(_emptyState), findsOneWidget);
   });
 }
 

--- a/integration_test/schedules_test.dart
+++ b/integration_test/schedules_test.dart
@@ -1,0 +1,163 @@
+// Patrol E2E tests for the Medication Schedules feature.
+//
+// These run on a real Android device/emulator (Patrol does not support Linux
+// desktop), driving the actual app launched via `main()`. Run with:
+//   patrol test --target integration_test/schedules_test.dart --flavor standalone
+// See integration_test/README.md for the full setup and CI notes.
+//
+// Finder strategy: the schedules UI defines no widget Keys, so we target
+// fields by their decoration label (`$(TextField).containing('Name')`) rather
+// than by index — pushed routes stay mounted underneath, so index-based
+// TextField finders would be ambiguous across the navigation stack.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mona/data/model/administration_route.dart';
+import 'package:mona/data/model/molecule.dart';
+import 'package:mona/main.dart' as app;
+import 'package:patrol/patrol.dart';
+
+// English l10n strings exercised by these tests (see lib/l10n/app_en.arb).
+const _emptyState = 'Add a schedule to get started.';
+const _schedulesTile = 'Schedules';
+const _nameLabel = 'Name';
+const _amountLabel = 'Amount';
+const _moleculeEstradiol = 'Estradiol';
+const _routeOral = 'Oral';
+const _next = 'Next';
+const _save = 'Save';
+const _intervalToggle = 'Interval';
+const _everyLabel = 'Every';
+const _addNotification = 'Add a notification';
+const _editScheduleInfo = 'Edit schedule info';
+const _delete = 'Delete';
+
+void main() {
+  patrolTest('shows empty state when there are no schedules', ($) async {
+    await _launchApp($);
+    await _openSchedules($);
+
+    await $(_emptyState).waitUntilVisible();
+    expect($(_emptyState), findsOneWidget);
+  });
+
+  patrolTest('creates an interval schedule', ($) async {
+    await _launchApp($);
+    await _openSchedules($);
+
+    await $(Icons.add).tap(); // FAB: "Add a schedule"
+    await _fillMainInfoAndNext($, name: 'Interval Estradiol');
+
+    await $(_intervalToggle).tap();
+    await $(TextField).containing(_everyLabel).enterText('3');
+    await $(_save).tap();
+
+    // provider.add() is fire-and-forget; wait for the list to rebuild.
+    await $('Interval Estradiol').waitUntilVisible();
+    expect($('Interval Estradiol'), findsOneWidget);
+  });
+
+  patrolTest('creates a daily schedule', ($) async {
+    await _launchApp($);
+    await _openSchedules($);
+
+    await $(Icons.add).tap();
+    await _fillMainInfoAndNext($, name: 'Daily Estradiol');
+
+    // "Every day" is the default type. Add one intake time via the time
+    // picker (a daily schedule requires at least one time to be valid).
+    await $(_addNotification).tap();
+    await $('OK').tap(); // accept the default time
+    await $(_save).tap();
+
+    await $('Daily Estradiol').waitUntilVisible();
+    expect($('Daily Estradiol'), findsOneWidget);
+  });
+
+  patrolTest('edits a schedule name', ($) async {
+    await _launchApp($);
+    await _openSchedules($);
+    await _createIntervalSchedule($, name: 'Old Name');
+
+    await $(ListTile).containing('Old Name').tap(); // -> EditSchedulePage
+    await $(_editScheduleInfo).tap(); // -> EditScheduleMainInfoPage
+    await $(TextField).containing(_nameLabel).enterText('New Name');
+    await $(_save).tap(); // pops back to EditSchedulePage
+
+    await $.tester.pageBack(); // back to the schedules list
+    await $.pumpAndSettle();
+
+    await $('New Name').waitUntilVisible();
+    expect($('New Name'), findsOneWidget);
+    expect($('Old Name'), findsNothing);
+  });
+
+  patrolTest('deletes a schedule with confirmation', ($) async {
+    await _launchApp($);
+    await _openSchedules($);
+    await _createIntervalSchedule($, name: 'To Delete');
+
+    await $(ListTile).containing('To Delete').tap();
+    await $(_editScheduleInfo).tap();
+
+    await $(_delete).tap(); // form's Delete button -> confirmation dialog
+    await $(AlertDialog).$(_delete).tap(); // confirm in the dialog
+
+    await $.tester.pageBack(); // EditSchedulePage -> schedules list
+    await $.pumpAndSettle();
+
+    await $(_emptyState).waitUntilVisible();
+    expect($('To Delete'), findsNothing);
+    expect($(_emptyState), findsOneWidget);
+  });
+}
+
+/// Launches the real app and waits for the home screen to be interactive.
+Future<void> _launchApp(PatrolIntegrationTester $) async {
+  app.main();
+  await $.pumpAndSettle();
+  // main() initialises asynchronously (timezone data, preferences) before
+  // runApp; poll until the home AppBar's settings button is on screen.
+  await $(Icons.settings).waitUntilVisible();
+}
+
+/// Home -> Settings -> Schedules.
+Future<void> _openSchedules(PatrolIntegrationTester $) async {
+  await $(Icons.settings).tap();
+  await $(_schedulesTile).scrollTo().tap();
+}
+
+/// Fills the first create-schedule page (name, molecule, route, amount) with a
+/// combination that does NOT surface the conditional Ester field
+/// (Estradiol + Oral), then taps "Next".
+Future<void> _fillMainInfoAndNext(
+  PatrolIntegrationTester $, {
+  required String name,
+  String dose = '2',
+}) async {
+  await $(TextField).containing(_nameLabel).enterText(name);
+
+  await $(DropdownButtonFormField<Molecule>).tap();
+  await $(_moleculeEstradiol).tap();
+
+  await $(DropdownButtonFormField<AdministrationRoute>).tap();
+  await $(_routeOral).tap();
+
+  await $(TextField).containing(_amountLabel).enterText(dose);
+
+  await $(_next).tap();
+}
+
+/// End-to-end helper: creates a minimal interval schedule and returns to the
+/// schedules list (used by the edit/delete tests as a precondition).
+Future<void> _createIntervalSchedule(
+  PatrolIntegrationTester $, {
+  required String name,
+}) async {
+  await $(Icons.add).tap();
+  await _fillMainInfoAndNext($, name: name);
+  await $(_intervalToggle).tap();
+  await $(TextField).containing(_everyLabel).enterText('3');
+  await $(_save).tap();
+  await $(ListTile).containing(name).waitUntilVisible();
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -10,6 +10,7 @@ import file_picker
 import flutter_local_notifications
 import flutter_timezone
 import package_info_plus
+import patrol
 import share_plus
 import shared_preferences_foundation
 import sqflite_darwin
@@ -21,6 +22,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterTimezonePlugin.register(with: registry.registrar(forPlugin: "FlutterTimezonePlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  PatrolPlugin.register(with: registry.registrar(forPlugin: "PatrolPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -233,6 +233,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.4"
+  dispose_scope:
+    dependency: transitive
+    description:
+      name: dispose_scope
+      sha256: "48ec38ca2631c53c4f8fa96b294c801e55c335db5e3fb9f82cede150cfe5a2af"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   dynamic_system_colors:
     dependency: "direct main"
     description:
@@ -308,6 +316,11 @@ packages:
     version: "1.2.0"
   flutter:
     dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_driver:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -406,6 +419,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  fuchsia_remote_debug_protocol:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   glob:
     dependency: transitive
     description:
@@ -470,6 +488,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.0"
+  integration_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   intl:
     dependency: "direct main"
     description:
@@ -726,6 +749,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  patrol:
+    dependency: "direct dev"
+    description:
+      name: patrol
+      sha256: f43fda9425e90c0e69d2dac9e495e3a3036a22a550466365b4720fa4dd53d6ae
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.6.1"
+  patrol_finders:
+    dependency: transitive
+    description:
+      name: patrol_finders
+      sha256: "915da1e63fe7fd024418ab30b2394b1c8d6e812ce25be7d0b11634202521f0a9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.0"
+  patrol_log:
+    dependency: transitive
+    description:
+      name: patrol_log
+      sha256: "16ab747b28621640115d9493138eae82a1d410a613857cb0caf9000ce62fc546"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.0"
   permission_handler:
     dependency: "direct main"
     description:
@@ -814,6 +861,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.5.0"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.5"
   provider:
     dependency: "direct main"
     description:
@@ -1043,6 +1098,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   synchronized:
     dependency: transitive
     description:
@@ -1235,6 +1298,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   win32:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "93.0.0"
+  adb:
+    dependency: transitive
+    description:
+      name: adb
+      sha256: "1c1d53b356bc9a7b89e7abcbb8b7b941f6d6ab0fc61a77eb8a4928befa294202"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   analyzer:
     dependency: transitive
     description:
@@ -17,6 +25,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "10.0.1"
+  ansi_styles:
+    dependency: transitive
+    description:
+      name: ansi_styles
+      sha256: "9c656cc12b3c27b17dd982b2cc5c0cfdfbdabd7bc8f3ae5e8542d9867b47ce8a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.2+1"
   ansicolor:
     dependency: transitive
     description:
@@ -121,6 +137,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.4"
+  ci:
+    dependency: transitive
+    description:
+      name: ci
+      sha256: "145d095ce05cddac4d797a158bc4cf3b6016d1fe63d8c3d2fbd7212590adca13"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0"
+  cli_completion:
+    dependency: transitive
+    description:
+      name: cli_completion
+      sha256: "72e8ccc4545f24efa7bbdf3bff7257dc9d62b072dee77513cc54295575bc9220"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.1"
+  cli_config:
+    dependency: transitive
+    description:
+      name: cli_config
+      sha256: ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   cli_util:
     dependency: transitive
     description:
@@ -169,6 +209,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  coverage:
+    dependency: transitive
+    description:
+      name: coverage
+      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.15.0"
   cross_file:
     dependency: transitive
     description:
@@ -565,6 +613,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.0"
+  mason_logger:
+    dependency: transitive
+    description:
+      name: mason_logger
+      sha256: "1d46102c6f299c0df7fe986dd3dd3271d57c2ec7c00ae590660b7c3018810048"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5"
   matcher:
     dependency: transitive
     description:
@@ -757,6 +813,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.6.1"
+  patrol_cli:
+    dependency: "direct dev"
+    description:
+      name: patrol_cli
+      sha256: "7970bcd73b4b8e1966e26ac698819ed84bf555148a9cb310aceba652a3915ac0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.4.0"
   patrol_finders:
     dependency: transitive
     description:
@@ -885,6 +949,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  pub_updater:
+    dependency: transitive
+    description:
+      name: pub_updater
+      sha256: "739a0161d73a6974c0675b864fb0cf5147305f7b077b7f03a58fa7a9ab3e7e7d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   pubspec_parse:
     dependency: transitive
     description:
@@ -1002,6 +1074,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.2.1"
+  source_maps:
+    dependency: transitive
+    description:
+      name: source_maps
+      sha256: "190222579a448b03896e0ca6eca5998fa810fda630c1d65e2f78b3f638f54812"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.13"
   source_span:
     dependency: transitive
     description:
@@ -1258,6 +1338,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  version:
+    dependency: transitive
+    description:
+      name: version
+      sha256: "3d4140128e6ea10d83da32fef2fa4003fccbf6852217bb854845802f04191f94"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -83,13 +83,16 @@ dev_dependencies:
   mockito: ^5.4.4
 
 # Patrol E2E configuration. See integration_test/README.md for how to run.
-# package_name is the base applicationId; debug test builds append `.dev`
-# (see android/app/build.gradle buildTypes.debug) and require a --flavor.
+# package_name MUST match the package the test build actually installs. Debug
+# builds append `.dev` (see android/app/build.gradle buildTypes.debug), so this
+# is the `.dev` id, NOT the base `com.deliacheminot.mona`. This matters: Patrol
+# uninstalls/reinstalls this package and `clearPackageData` wipes its data
+# between tests — pointing it at the base id would destroy a production install.
 patrol:
   app_name: Mona
   test_directory: integration_test
   android:
-    package_name: com.deliacheminot.mona
+    package_name: com.deliacheminot.mona.dev
   ios:
     bundle_id: com.deliacheminot.mona
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -72,11 +72,25 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
+  patrol: ^4.6.1
   build_runner: ^2.4.9
   fake_async: ^1.3.1
   dart_mappable_builder: ^4.8.0
   flutter_lints: ^6.0.0
   mockito: ^5.4.4
+
+# Patrol E2E configuration. See integration_test/README.md for how to run.
+# package_name is the base applicationId; debug test builds append `.dev`
+# (see android/app/build.gradle buildTypes.debug) and require a --flavor.
+patrol:
+  app_name: Mona
+  test_directory: integration_test
+  android:
+    package_name: com.deliacheminot.mona
+  ios:
+    bundle_id: com.deliacheminot.mona
 
 flutter_launcher_icons:
   android: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -75,6 +75,7 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   patrol: ^4.6.1
+  patrol_cli: ^4.4.0
   build_runner: ^2.4.9
   fake_async: ^1.3.1
   dart_mappable_builder: ^4.8.0


### PR DESCRIPTION
### Description

Adds end-to-end UI tests for the **Medication Schedules** feature using [Patrol](https://patrol.leancode.co) on top of Flutter's `integration_test`, plus the native wiring and a dedicated CI job to run them on an Android emulator.

We previously had no automated coverage that drives the real app the way a user does. These tests launch the app via `main()` and exercise the core scheduleflows (empty state, create/edit/delete, interval vs. daily, notifications), catching regressions that widget/unit tests can't.

**What's included:**

- **E2E tests** : `integration_test/schedules_test.dart` covering the empty state and create/edit/delete flows for interval and daily schedules. The schedules UI defines no widget `Key`s, so fields are targeted by their visible label rather than by index (pushed routes stay mounted underneath, making index-based finders ambiguous). Other views and features will be covered by e2e tests later.

- **Android native wiring** (`android/app/build.gradle`, `MainActivityTest.java`) :  `PatrolJUnitRunner`, the `ANDROIDX_TEST_ORCHESTRATOR` test option, and the orchestrator dependency for `clearPackageData` test isolation.

- **CI** : new `.github/workflows/ci-e2e.yml` that boots a KVM-accelerated emulator via `android-emulator-runner` (api 34, pixel_6). Kept separate from `ci-pr.yml` because the emulator makes it slow; Patrol results are uploaded as an artifact.

- **Tooling** : `patrol` + `patrol_cli` added as `dev_dependency` (pinned in `pubspec.lock`); `patrol:` config in `pubspec.yaml`; dev container runs `pub get` on create and can attach to a host emulator over ADB.

- **Docs** : `integration_test/README.md` with setup, how to run locally / from the dev container, and the iOS follow-up plan.

- **Flaky test fix**:  made `notification_scheduler_test` deterministic by using `yesterday`/`tomorrow` at fixed noon instead of `now +/- 1h` . It was necessary to fix this test even though it's unrelated to this feature branch because a unit test would fail if ran around midnight and prevent this PR to be merged.

**⚠️ Data-loss safety note:** tests run against `com.deliacheminot.mona.dev` (debug `applicationIdSuffix`), deliberately separate from a released install. `package_name` must not point at the base id. Patrol's reinstall + `clearPackageData` would wipe a production install. See `integration_test/README.md`.

**Out of scope / follow-up:** iOS is not wired yet - it requires Xcode project changes that can't be made or verified from the Linux dev container. Steps are documented in the README.

Related to issue(s): #224 

### Type of change
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update
- Maintenance

### Screenshots (if appropriate):
N/A -  see CI artifacts (`patrol-results`) for emulator run output.
