### PR TITLE
Make time-dependent tests deterministic with the clock package

### DIFF
--- a/lib/controllers/notification_scheduler.dart
+++ b/lib/controllers/notification_scheduler.dart
@@ -1,3 +1,4 @@
+import 'package:clock/clock.dart';
 import 'package:intl/intl.dart';
 import 'package:mona/controllers/occurrences_manager.dart';
 import 'package:mona/data/model/medication_schedule.dart';
@@ -20,7 +21,7 @@ class NotificationScheduler {
 
   List<_ScheduledNotification> _getScheduledNotifications() {
     final notifications = <_ScheduledNotification>[];
-    final now = DateTime.now();
+    final now = clock.now();
 
     for (final occ in occurencesManager.upcoming(days: _numberOfDays)) {
       if (!occ.notifiable) continue;

--- a/lib/data/model/date.dart
+++ b/lib/data/model/date.dart
@@ -1,3 +1,4 @@
+import 'package:clock/clock.dart';
 import 'package:intl/intl.dart';
 
 bool _isUtcMidnight(DateTime dt) =>
@@ -19,7 +20,7 @@ class Date {
 
   Date.fromDateTime(DateTime input) : value = _logicalDay(input);
 
-  Date.today() : value = _logicalDay(DateTime.now());
+  Date.today() : value = _logicalDay(clock.now());
 
   Date.fromString(String input) : value = DateTime.parse(input) {
     if (!_isUtcMidnight(value)) {

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
+import 'package:clock/clock.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_timezone/flutter_timezone.dart';
@@ -188,7 +189,7 @@ class NotificationService {
       final scheduledTime =
           (payload['scheduledTime'] as String).toDateTimeOrNull;
       if (scheduledTime == null) return false;
-      return scheduledTime.isBefore(DateTime.now());
+      return scheduledTime.isBefore(clock.now());
     }).toList();
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -130,7 +130,7 @@ packages:
     source: hosted
     version: "0.4.2"
   clock:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: clock
       sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
@@ -259,7 +259,7 @@ packages:
     source: hosted
     version: "2.0.8"
   fake_async:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: fake_async
       sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   sqflite: ^2.3.3+1
   sqflite_common_ffi: ^2.0.0+2
   path: ^1.9.0
+  clock: ^1.1.1
   decimal: ^3.2.4
   flutter_svg: ^2.2.3
   graph_calculator: ^0.0.4
@@ -72,6 +73,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   build_runner: ^2.4.9
+  fake_async: ^1.3.1
   dart_mappable_builder: ^4.8.0
   flutter_lints: ^6.0.0
   mockito: ^5.4.4

--- a/test/controllers/notification_scheduler_test.dart
+++ b/test/controllers/notification_scheduler_test.dart
@@ -1,3 +1,4 @@
+import 'package:clock/clock.dart';
 import 'package:decimal/decimal.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
@@ -19,6 +20,8 @@ import 'package:mona/services/notification_service.dart';
 import 'package:mona/services/preferences_service.dart';
 import 'package:timezone/data/latest_all.dart' as tz;
 import 'package:timezone/timezone.dart' as tz;
+
+import '../util/test_clock.dart';
 
 @GenerateNiceMocks([
   MockSpec<OccurrencesManager>(),
@@ -125,49 +128,53 @@ void main() {
 
   group('pending notifications', () {
     test('regenerateAll triggers past pending notifications', () async {
-      final pending = PendingNotificationRequest(
-        1,
-        'title',
-        'body',
-        '{"scheduledTime":"${DateTime.now().subtract(const Duration(days: 1)).toIso8601String()}"}',
-      );
-      when(plugin.pendingNotificationRequests())
-          .thenAnswer((_) async => [pending]);
-      when(plugin.show(
-        id: anyNamed('id'),
-        title: anyNamed('title'),
-        body: anyNamed('body'),
-        notificationDetails: anyNamed('notificationDetails'),
-        payload: anyNamed('payload'),
-      )).thenAnswer((_) async {});
-      final sut = NotificationScheduler(occurrences, preferences);
+      await withFixedClockAsync(() async {
+        final pending = PendingNotificationRequest(
+          1,
+          'title',
+          'body',
+          '{"scheduledTime":"${clock.now().subtract(const Duration(days: 1)).toIso8601String()}"}',
+        );
+        when(plugin.pendingNotificationRequests())
+            .thenAnswer((_) async => [pending]);
+        when(plugin.show(
+          id: anyNamed('id'),
+          title: anyNamed('title'),
+          body: anyNamed('body'),
+          notificationDetails: anyNamed('notificationDetails'),
+          payload: anyNamed('payload'),
+        )).thenAnswer((_) async {});
+        final sut = NotificationScheduler(occurrences, preferences);
 
-      await sut.regenerateAll(l10n, 'en');
+        await sut.regenerateAll(l10n, 'en');
 
-      verify(plugin.show(
-        id: anyNamed('id'),
-        title: argThat(equals('title'), named: 'title'),
-        body: argThat(equals('body'), named: 'body'),
-        notificationDetails: anyNamed('notificationDetails'),
-        payload: anyNamed('payload'),
-      )).called(1);
+        verify(plugin.show(
+          id: anyNamed('id'),
+          title: argThat(equals('title'), named: 'title'),
+          body: argThat(equals('body'), named: 'body'),
+          notificationDetails: anyNamed('notificationDetails'),
+          payload: anyNamed('payload'),
+        )).called(1);
+      });
     });
 
     test('regenerateAll cancels pending notifications', () async {
-      final pending = PendingNotificationRequest(
-        1,
-        'title',
-        'body',
-        '{"scheduledTime":"${DateTime.now().add(const Duration(days: 1)).toIso8601String()}"}',
-      );
-      when(plugin.pendingNotificationRequests())
-          .thenAnswer((_) async => [pending]);
-      when(plugin.cancel(id: anyNamed('id'))).thenAnswer((_) async {});
-      final sut = NotificationScheduler(occurrences, preferences);
+      await withFixedClockAsync(() async {
+        final pending = PendingNotificationRequest(
+          1,
+          'title',
+          'body',
+          '{"scheduledTime":"${clock.now().add(const Duration(days: 1)).toIso8601String()}"}',
+        );
+        when(plugin.pendingNotificationRequests())
+            .thenAnswer((_) async => [pending]);
+        when(plugin.cancel(id: anyNamed('id'))).thenAnswer((_) async {});
+        final sut = NotificationScheduler(occurrences, preferences);
 
-      await sut.regenerateAll(l10n, l10n.localeName);
+        await sut.regenerateAll(l10n, l10n.localeName);
 
-      verify(plugin.cancel(id: anyNamed('id'))).called(1);
+        verify(plugin.cancel(id: anyNamed('id'))).called(1);
+      });
     });
   });
 
@@ -307,22 +314,24 @@ void main() {
     });
 
     test('skips occurrences whose dateTime is in the past', () async {
-      final s = schedule();
-      final now = DateTime.now();
-      final pastTime =
-          TimeOfDay.fromDateTime(now.subtract(const Duration(hours: 1)));
-      final futureTime =
-          TimeOfDay.fromDateTime(now.add(const Duration(hours: 1)));
+      await withFixedClockAsync(() async {
+        final s = schedule();
+        final now = clock.now();
+        final pastTime =
+            TimeOfDay.fromDateTime(now.subtract(const Duration(hours: 1)));
+        final futureTime =
+            TimeOfDay.fromDateTime(now.add(const Duration(hours: 1)));
 
-      when(occurrences.upcoming(days: 5)).thenReturn([
-        occurrence(schedule: s, date: Date.today(), time: pastTime),
-        occurrence(schedule: s, date: Date.today(), time: futureTime),
-      ]);
-      final sut = NotificationScheduler(occurrences, preferences);
+        when(occurrences.upcoming(days: 5)).thenReturn([
+          occurrence(schedule: s, date: Date.today(), time: pastTime),
+          occurrence(schedule: s, date: Date.today(), time: futureTime),
+        ]);
+        final sut = NotificationScheduler(occurrences, preferences);
 
-      await sut.regenerateAll(l10n, l10n.localeName);
+        await sut.regenerateAll(l10n, l10n.localeName);
 
-      verifyScheduled().called(1);
+        verifyScheduled().called(1);
+      });
     });
 
     test('titles notifications with the schedule name', () async {

--- a/test/data/model/date_test.dart
+++ b/test/data/model/date_test.dart
@@ -1,9 +1,12 @@
+import 'package:clock/clock.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:intl/intl.dart';
 import 'package:mona/data/model/date.dart';
 import 'package:timezone/data/latest_all.dart' as tz;
 import 'package:timezone/timezone.dart';
+
+import '../../util/test_clock.dart';
 
 void main() {
   setUpAll(() async {
@@ -165,37 +168,40 @@ void main() {
     });
 
     group('today', () {
-      test('Date.today() is today (or yesterday if it is before 4am)', () {
-        // Arrange
-        final now = DateTime.now().toUtc();
-        final logicalDay =
-            now.hour < 4 ? now.subtract(const Duration(days: 1)) : now;
-        final todayWithConstructor = Date(
-            DateTime.utc(logicalDay.year, logicalDay.month, logicalDay.day));
+      test('Date.today() is the current logical day after 4am', () {
+        withFixedClock(() {
+          // Act & Assert
+          expect(Date.today(), Date(DateTime.utc(2026, 6, 1)));
+        }, at: DateTime(2026, 6, 1, 12, 0));
+      });
 
-        // Act
-        final today = Date.today();
-
-        // Assert
-        expect(today, todayWithConstructor);
+      test('Date.today() rolls back to the previous day before 4am', () {
+        withFixedClock(() {
+          // Act & Assert
+          expect(Date.today(), Date(DateTime.utc(2026, 5, 31)));
+        }, at: DateTime(2026, 6, 1, 3, 0));
       });
 
       test('isToday is true for today', () {
-        // Arrange
-        final today = Date.today();
+        withFixedClock(() {
+          // Arrange
+          final today = Date.today();
 
-        // Act & Assert
-        expect(today.isToday, isTrue);
+          // Act & Assert
+          expect(today.isToday, isTrue);
+        });
       });
 
       test('isToday is false for dates other than today', () {
-        // Arrange
-        final yesterday = Date.fromDateTime(
-          DateTime.now().subtract(const Duration(days: 1)),
-        );
+        withFixedClock(() {
+          // Arrange
+          final yesterday = Date.fromDateTime(
+            clock.now().subtract(const Duration(days: 1)),
+          );
 
-        // Act & Assert
-        expect(yesterday.isToday, isFalse);
+          // Act & Assert
+          expect(yesterday.isToday, isFalse);
+        });
       });
     });
 
@@ -237,23 +243,27 @@ void main() {
 
     group('daysAwayFromToday', () {
       test('today is 0 days away', () {
-        // Arrange
-        final today = Date.today();
+        withFixedClock(() {
+          // Arrange
+          final today = Date.today();
 
-        // Act & Assert
-        expect(today.daysAwayFromToday, 0);
+          // Act & Assert
+          expect(today.daysAwayFromToday, 0);
+        });
       });
 
       test('yesterday and tomorrow are both 1 day away', () {
-        // Arrange
-        final now = DateTime.now();
-        final yesterday =
-            Date.fromDateTime(now.subtract(const Duration(days: 1)));
-        final tomorrow = Date.fromDateTime(now.add(const Duration(days: 1)));
+        withFixedClock(() {
+          // Arrange
+          final now = clock.now();
+          final yesterday =
+              Date.fromDateTime(now.subtract(const Duration(days: 1)));
+          final tomorrow = Date.fromDateTime(now.add(const Duration(days: 1)));
 
-        // Act & Assert
-        expect(yesterday.daysAwayFromToday, 1);
-        expect(tomorrow.daysAwayFromToday, 1);
+          // Act & Assert
+          expect(yesterday.daysAwayFromToday, 1);
+          expect(tomorrow.daysAwayFromToday, 1);
+        });
       });
     });
 

--- a/test/data/model/medication_intake_test.dart
+++ b/test/data/model/medication_intake_test.dart
@@ -17,7 +17,7 @@ void main() {
       expect(
         () => MedicationIntake(
           dose: Decimal.one,
-          takenDateTime: DateTime(2025, 9, 14, 12, 0), // local (non-UTC)
+          takenDateTime: DateTime(2025, 9, 14, 12, 0),
           takenTimeZone: 'Etc/UTC',
           molecule: KnownMolecules.estradiol,
           administrationRoute: AdministrationRoute.oral,

--- a/test/data/model/medication_intake_test.dart
+++ b/test/data/model/medication_intake_test.dart
@@ -17,7 +17,7 @@ void main() {
       expect(
         () => MedicationIntake(
           dose: Decimal.one,
-          takenDateTime: DateTime.now(),
+          takenDateTime: DateTime(2025, 9, 14, 12, 0), // local (non-UTC)
           takenTimeZone: 'Etc/UTC',
           molecule: KnownMolecules.estradiol,
           administrationRoute: AdministrationRoute.oral,

--- a/test/services/notification_service_test.dart
+++ b/test/services/notification_service_test.dart
@@ -1,9 +1,12 @@
 import 'dart:convert';
+import 'package:clock/clock.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mona/services/notification_service.dart';
 import 'package:timezone/data/latest_all.dart' as tzdata;
 import 'package:timezone/timezone.dart' as tz;
+
+import '../util/test_clock.dart';
 
 class FakeFlutterLocalNotificationsPlugin
     implements FlutterLocalNotificationsPlugin {
@@ -199,20 +202,22 @@ void main() {
   });
 
   test('triggerPastPendingNotifications shows past notifications', () async {
-    final payload = jsonEncode({
-      'scheduledTime':
-          DateTime.now().subtract(Duration(days: 1)).toIso8601String()
-    });
-    fakePlugin.scheduled.add({
-      'id': 1,
-      'title': 'Past',
-      'body': 'B',
-      'date': DateTime.now(),
-      'payload': payload
-    });
+    await withFixedClockAsync(() async {
+      final payload = jsonEncode({
+        'scheduledTime':
+            clock.now().subtract(Duration(days: 1)).toIso8601String()
+      });
+      fakePlugin.scheduled.add({
+        'id': 1,
+        'title': 'Past',
+        'body': 'B',
+        'date': clock.now(),
+        'payload': payload
+      });
 
-    await service.triggerPastPendingNotifications();
-    expect(fakePlugin.shown.length, 1);
-    expect(fakePlugin.shown.first['title'], 'Past');
+      await service.triggerPastPendingNotifications();
+      expect(fakePlugin.shown.length, 1);
+      expect(fakePlugin.shown.first['title'], 'Past');
+    });
   });
 }

--- a/test/util/test_clock.dart
+++ b/test/util/test_clock.dart
@@ -1,0 +1,32 @@
+import 'package:clock/clock.dart';
+import 'package:fake_async/fake_async.dart';
+
+/// A fixed instant shared across tests so that any code reading the clock
+/// (`clock.now()`, and therefore `Date.today()`, the notification scheduler,
+/// etc.) behaves identically regardless of the wall-clock time at which the
+/// suite runs.
+///
+/// It is local noon, deliberately well clear of the day boundaries that make
+/// date logic flaky (midnight and the 4am "logical day" rule in [Date]).
+final DateTime testNow = DateTime(2026, 6, 1, 12, 0);
+
+/// Runs synchronous [body] with the clock frozen at [at] (defaults to
+/// [testNow]). Inside, `clock.now()` returns [at].
+///
+/// Backed by [fakeAsync], so a test that needs to advance time can use the
+/// [fakeAsync] form directly and call `async.elapse(...)` instead.
+T withFixedClock<T>(T Function() body, {DateTime? at}) =>
+    fakeAsync((_) => body(), initialTime: at ?? testNow);
+
+/// Runs asynchronous [body] with the clock frozen at [at] (defaults to
+/// [testNow]), awaiting real futures normally.
+///
+/// Use this instead of [withFixedClock] when the test `await`s genuine
+/// asynchronous work (e.g. mocked plugin calls): [withClock] only swaps the
+/// clock and leaves the event loop untouched, whereas [fakeAsync] would also
+/// fake timers and require manual flushing of microtasks.
+Future<T> withFixedClockAsync<T>(
+  Future<T> Function() body, {
+  DateTime? at,
+}) =>
+    withClock(Clock.fixed(at ?? testNow), body);

--- a/test/util/validators_test.dart
+++ b/test/util/validators_test.dart
@@ -32,7 +32,7 @@ void main() {
       // Arrange
       final cases = [
         {'value': null, 'expected': isNotNull},
-        {'value': DateTime.now(), 'expected': isNull},
+        {'value': DateTime(2026, 6, 1, 12, 0), 'expected': isNull},
       ];
 
       // Act


### PR DESCRIPTION
## Description

Some unit tests were a "ticking bomb": they indirectly depended on the real wall-clock time because the production code they exercise called `DateTime.now()` directly. 
With no seam to override, the same test could pass or fail depending on the time of day (or the machine's timezone) it ran at : e.g. around midnight or the 4am "logical day" boundary, making CI non-deterministic.

This PR introduces the Dart team's [`clock`](https://pub.dev/packages/clock) package as a single, overridable source of "now", so the time-dependent code paths can be frozen in tests while behaving identically in the running app.

### Production (`lib/`)  
`DateTime.now()` -> `clock.now()` on the paths the tests assert on. No runtime behavior change: with no override, `clock.now()` returns the real clock.

### Tests 
Freeze the clock to a fixed instant so the test and the code under test agree on "now".
- New shared helper `test_clock.dart` :
  `withFixedClock` (sync, via `fakeAsync`) and `withFixedClockAsync` (async, via `withClock`), plus a shared `testNow`.
- Updated `date_test`, `notification_scheduler_test`, and `notification_service_test` to run their time-sensitive cases under a frozen clock. Removed the last `DateTime.now()` calls from `medication_intake_test` and `validators_test` (replaced with fixed literals).
- Also fixes a latent test bug: the old `Date.today()` test checked the 4am rule against **UTC** time while the code applies it against **local** time. The rewrite asserts concrete dates and deterministically covers both branches.

### Dependencies 
Adds two deps that were already present transitively (via `flutter_test`), now declared explicitly because we import them directly. Resolution is unchanged (`fvm flutter pub get` only): `clock` -> `dependencies`, `fake_async` -> `dev_dependencies`. 

Related to issue(s): #226 

## Type of changes
- Bug fix (non-breaking change which fixes an issue)
- Maintenance