### PR TITLE
Test (intakes) : add Patrol E2E tests + stable widget keys for the Intakes feature

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -25,11 +25,36 @@ jobs:
           flutter-version-file: .fvmrc
           cache: true
 
+      # Pin a JDK for the Android Gradle build so it never falls back to an
+      # invalid JAVA_HOME (AGP needs JDK 17).
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
       - name: Get dependencies
         # Installs the Patrol framework AND the Patrol CLI: patrol_cli is a
         # dev_dependency (pinned in pubspec.lock), so there is no separate
         # `dart pub global activate`. The CLI is run as `dart run patrol_cli:main`.
         run: flutter pub get
+
+      # Cache the Gradle home so the Android build isn't cold on every run
+      # (a cold build re-downloads AGP + deps and can take 10–20 min by itself).
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('android/**/*.gradle*', 'android/gradle/wrapper/gradle-wrapper.properties', 'pubspec.lock') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+
+      # Build the app + instrumentation APKs outside the emulator.
+      - name: Build Patrol APKs
+        timeout-minutes: 25
+        run: dart run patrol_cli:main build android --flavor standalone --verbose
 
       - name: Enable KVM
         run: |
@@ -44,6 +69,7 @@ jobs:
       # in pubspec.yaml. Omitting --target runs every *_test.dart under
       # integration_test/ (the test_directory in pubspec.yaml).
       - name: Run Patrol tests on emulator
+        timeout-minutes: 30
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 34

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -54,7 +54,7 @@ jobs:
       # Build the app + instrumentation APKs outside the emulator.
       - name: Build Patrol APKs
         timeout-minutes: 25
-        run: dart run patrol_cli:main build android --flavor standalone --verbose
+        run: dart run patrol_cli:main build android --flavor standalone
 
       - name: Enable KVM
         run: |

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -82,12 +82,30 @@ the `.dev` id to match, so Patrol only ever manages the test build.
 
 ## Writing tests - notes for this app
 
-The schedules UI defines **no widget `Key`s**, so tests target widgets by their
-visible (English) label, e.g. `$(TextField).containing('Name')`. This is
-deliberate: when a route is pushed the previous route stays mounted, so
-index-based `TextField` finders are ambiguous across the navigation stack -
-prefer label-scoped finders. If the UI strings change, update the `const`
-labels at the top of the test file.
+### Finder strategy (hybrid)
+
+Drive **interactions** (taps, text entry) through stable widget `Key`s set in
+the production code, and keep **assertions** matching on user-visible text.
+
+- **Interaction targets : Keys.** Targeting a button or input by its visible
+  label couples the test to (a) the English copy and (b) the device locale, and
+  can be ambiguous when a pushed route leaves the previous one mounted
+  underneath. A `ValueKey` on the production widget avoids all three. Declare
+  the keys as `const ValueKey(...)` at the top of the test file, matching the
+  ones set in `lib/ui/...`. For widgets reused across routes (e.g. a form's
+  submit button), pass a **page-specific** key rather than one shared key -
+  pushed routes stay mounted, so a single key would be ambiguous across the
+  navigation stack.
+- **Assertions : visible text.** When the displayed copy *is* the behaviour
+  under test (empty states, dialog titles, persisted values), assert on the
+  text directly (`$('Taken intakes will appear here')`). A key there would
+  weaken the assertion.
+- **Stable non-text finders are fine as-is** Icons (`$(Icons.add)`), widget
+  types (`$(ListTile)`), and user data that isn't localized (a schedule's name).
+
+When adding keys, prefer threading an optional key param through the shared
+widgets (`ModelForm`, `FormTextField`, `Dialogs`, `MainTabConfig`) so other
+features can reuse them; the params are optional and backward-compatible.
 
 ## iOS (follow-up - not yet wired)
 

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -82,6 +82,12 @@ the `.dev` id to match, so Patrol only ever manages the test build.
 
 ## Writing tests - notes for this app
 
+### State between tests
+
+`clearPackageData: "true"` (`android/app/build.gradle`) wipes app data between
+Dart tests, so each test starts from an empty database and must seed its own
+preconditions (e.g. recording an intake needs a schedule to exist first).
+
 ### Finder strategy (hybrid)
 
 Drive **interactions** (taps, text entry) through stable widget `Key`s set in

--- a/integration_test/intakes_test.dart
+++ b/integration_test/intakes_test.dart
@@ -1,14 +1,4 @@
 // Patrol E2E tests for the Intakes feature.
-//
-// These run on a real Android device/emulator (Patrol does not support Linux
-// desktop), driving the actual app launched via `main()`. Run with:
-//   patrol test --target integration_test/intakes_test.dart --flavor standalone
-// See integration_test/README.md for the full setup and CI notes.
-//
-// State note: `clearPackageData: "true"` (android/app/build.gradle) wipes app
-// data between Dart tests, so each test starts from an empty database and must
-// seed its own preconditions. Recording an intake requires at least one
-// schedule to exist, so the tests create one via Settings -> Schedules first.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -27,12 +17,10 @@ const _editIntakeDelete = ValueKey('editIntakeDelete');
 const _editIntakeNotes = ValueKey('editIntakeNotes');
 const _confirmDelete = ValueKey('confirmDeleteConfirmButton');
 
-// User-visible strings asserted by these tests (see lib/l10n/app_en.arb).
 const _emptyIntakes = 'Taken intakes will appear here';
 const _addSchedulesFirst = 'Add schedules first.';
 const _editIntake = 'Edit intake';
 
-// Strings reused from the schedules flow to seed a schedule precondition.
 const _schedulesTile = 'Schedules';
 const _nameLabel = 'Name';
 const _amountLabel = 'Amount';
@@ -84,13 +72,11 @@ void main() {
     await _recordIntake($, scheduleName: 'Estradiol');
     await $(ListTile).waitUntilVisible();
 
-    // Open the recorded intake and add a note.
     await $(ListTile).tap(); // -> EditIntakePage
     await $(_editIntake).waitUntilVisible();
     await $(_editIntakeNotes).enterText('Felt fine');
     await $(_editIntakeSave).tap(); // pops back to the intakes list
 
-    // Reopen the intake; the note must have persisted.
     await $(ListTile).waitUntilVisible();
     await $(ListTile).tap();
     await $('Felt fine').waitUntilVisible();

--- a/integration_test/intakes_test.dart
+++ b/integration_test/intakes_test.dart
@@ -9,11 +9,6 @@
 // data between Dart tests, so each test starts from an empty database and must
 // seed its own preconditions. Recording an intake requires at least one
 // schedule to exist, so the tests create one via Settings -> Schedules first.
-//
-// Finder strategy: the intakes UI defines no widget Keys, so we target fields
-// by their decoration label (`$(TextField).containing('Notes')`) rather than by
-// index — pushed routes stay mounted underneath, so index-based TextField
-// finders would be ambiguous across the navigation stack.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -22,18 +17,25 @@ import 'package:mona/data/model/molecule.dart';
 import 'package:mona/main.dart' as app;
 import 'package:patrol/patrol.dart';
 
-// English l10n strings exercised by these tests (see lib/l10n/app_en.arb).
-const _navIntakes = 'Intakes';
+// Widget Keys on intake interaction targets (must match the ValueKeys set in
+// the production widgets: main_tabs.dart, model_form.dart, form_text_field.dart,
+// dialogs.dart).
+const _navTabIntakes = ValueKey('navTabIntakes');
+const _takeIntakeSubmit = ValueKey('takeIntakeSubmit');
+const _editIntakeSave = ValueKey('editIntakeSave');
+const _editIntakeDelete = ValueKey('editIntakeDelete');
+const _editIntakeNotes = ValueKey('editIntakeNotes');
+const _confirmDelete = ValueKey('confirmDeleteConfirmButton');
+
+// User-visible strings asserted by these tests (see lib/l10n/app_en.arb).
 const _emptyIntakes = 'Taken intakes will appear here';
+const _addSchedulesFirst = 'Add schedules first.';
 const _editIntake = 'Edit intake';
-const _takeIntake = 'Take intake';
-const _notesLabel = 'Notes';
-const _amountLabel = 'Amount';
-const _delete = 'Delete';
 
 // Strings reused from the schedules flow to seed a schedule precondition.
 const _schedulesTile = 'Schedules';
 const _nameLabel = 'Name';
+const _amountLabel = 'Amount';
 const _moleculeEstradiol = 'Estradiol';
 const _routeOral = 'Oral';
 const _next = 'Next';
@@ -48,6 +50,17 @@ void main() {
 
     await $(_emptyIntakes).waitUntilVisible();
     expect($(_emptyIntakes), findsOneWidget);
+  });
+
+  patrolTest('prompts to add a schedule when none exist', ($) async {
+    // With no schedules, the record-intake entry view (ChooseSchedulePage)
+    // shows a prompt instead of a selectable schedule list.
+    await _launchApp($);
+    await _openIntakes($);
+
+    await $(Icons.add).tap(); // FAB: "Take an intake" -> ChooseSchedulePage
+    await $(_addSchedulesFirst).waitUntilVisible();
+    expect($(_addSchedulesFirst), findsOneWidget);
   });
 
   patrolTest('records an intake from the intakes tab', ($) async {
@@ -74,8 +87,8 @@ void main() {
     // Open the recorded intake and add a note.
     await $(ListTile).tap(); // -> EditIntakePage
     await $(_editIntake).waitUntilVisible();
-    await $(TextField).containing(_notesLabel).enterText('Felt fine');
-    await $(_save).tap(); // pops back to the intakes list
+    await $(_editIntakeNotes).enterText('Felt fine');
+    await $(_editIntakeSave).tap(); // pops back to the intakes list
 
     // Reopen the intake; the note must have persisted.
     await $(ListTile).waitUntilVisible();
@@ -94,8 +107,8 @@ void main() {
     await $(ListTile).tap(); // -> EditIntakePage
     await $(_editIntake).waitUntilVisible();
 
-    await $(_delete).tap(); // form's Delete button -> confirmation dialog
-    await $(AlertDialog).$(_delete).tap(); // confirm in the dialog
+    await $(_editIntakeDelete).tap(); // form's Delete button -> confirmation dialog
+    await $(_confirmDelete).tap(); // confirm in the dialog
 
     await $(_emptyIntakes).waitUntilVisible();
     expect($(_emptyIntakes), findsOneWidget);
@@ -114,7 +127,7 @@ Future<void> _launchApp(PatrolIntegrationTester $) async {
 
 /// Switches from the Home tab to the Intakes tab via the bottom navigation bar.
 Future<void> _openIntakes(PatrolIntegrationTester $) async {
-  await $(_navIntakes).tap(); // NavigationDestination label
+  await $(_navTabIntakes).tap(); // keyed NavigationDestination
 }
 
 /// Seeds a minimal interval schedule (Estradiol + Oral) so an intake can be
@@ -156,7 +169,7 @@ Future<void> _recordIntake(
   required String scheduleName,
 }) async {
   await $(Icons.add).tap(); // FAB: "Take an intake" -> ChooseSchedulePage
-  await $(scheduleName).tap(); // pick the schedule -> TakeMedicationPage
-  await $(_takeIntake).tap(); // submit, pops back to the intakes list
+  await $(scheduleName).tap(); // pick the schedule (data, not localized)
+  await $(_takeIntakeSubmit).tap(); // submit, pops back to the intakes list
 }
 

--- a/integration_test/intakes_test.dart
+++ b/integration_test/intakes_test.dart
@@ -1,0 +1,162 @@
+// Patrol E2E tests for the Intakes feature.
+//
+// These run on a real Android device/emulator (Patrol does not support Linux
+// desktop), driving the actual app launched via `main()`. Run with:
+//   patrol test --target integration_test/intakes_test.dart --flavor standalone
+// See integration_test/README.md for the full setup and CI notes.
+//
+// State note: `clearPackageData: "true"` (android/app/build.gradle) wipes app
+// data between Dart tests, so each test starts from an empty database and must
+// seed its own preconditions. Recording an intake requires at least one
+// schedule to exist, so the tests create one via Settings -> Schedules first.
+//
+// Finder strategy: the intakes UI defines no widget Keys, so we target fields
+// by their decoration label (`$(TextField).containing('Notes')`) rather than by
+// index — pushed routes stay mounted underneath, so index-based TextField
+// finders would be ambiguous across the navigation stack.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mona/data/model/administration_route.dart';
+import 'package:mona/data/model/molecule.dart';
+import 'package:mona/main.dart' as app;
+import 'package:patrol/patrol.dart';
+
+// English l10n strings exercised by these tests (see lib/l10n/app_en.arb).
+const _navIntakes = 'Intakes';
+const _emptyIntakes = 'Taken intakes will appear here';
+const _editIntake = 'Edit intake';
+const _takeIntake = 'Take intake';
+const _notesLabel = 'Notes';
+const _amountLabel = 'Amount';
+const _delete = 'Delete';
+
+// Strings reused from the schedules flow to seed a schedule precondition.
+const _schedulesTile = 'Schedules';
+const _nameLabel = 'Name';
+const _moleculeEstradiol = 'Estradiol';
+const _routeOral = 'Oral';
+const _next = 'Next';
+const _save = 'Save';
+const _intervalToggle = 'Interval';
+const _everyLabel = 'Every';
+
+void main() {
+  patrolTest('shows empty state when there are no intakes', ($) async {
+    await _launchApp($);
+    await _openIntakes($);
+
+    await $(_emptyIntakes).waitUntilVisible();
+    expect($(_emptyIntakes), findsOneWidget);
+  });
+
+  patrolTest('records an intake from the intakes tab', ($) async {
+    await _launchApp($);
+    await _seedSchedule($, name: 'Estradiol');
+    await _openIntakes($);
+
+    await _recordIntake($, scheduleName: 'Estradiol');
+
+    // takeMedication() is fire-and-forget; wait for the list to rebuild. The
+    // recorded intake replaces the empty state with a ListTile.
+    await $(ListTile).waitUntilVisible();
+    expect($(_emptyIntakes), findsNothing);
+    expect($(ListTile), findsWidgets);
+  });
+
+  patrolTest('edits an intake and persists notes', ($) async {
+    await _launchApp($);
+    await _seedSchedule($, name: 'Estradiol');
+    await _openIntakes($);
+    await _recordIntake($, scheduleName: 'Estradiol');
+    await $(ListTile).waitUntilVisible();
+
+    // Open the recorded intake and add a note.
+    await $(ListTile).tap(); // -> EditIntakePage
+    await $(_editIntake).waitUntilVisible();
+    await $(TextField).containing(_notesLabel).enterText('Felt fine');
+    await $(_save).tap(); // pops back to the intakes list
+
+    // Reopen the intake; the note must have persisted.
+    await $(ListTile).waitUntilVisible();
+    await $(ListTile).tap();
+    await $('Felt fine').waitUntilVisible();
+    expect($('Felt fine'), findsOneWidget);
+  });
+
+  patrolTest('deletes an intake with confirmation', ($) async {
+    await _launchApp($);
+    await _seedSchedule($, name: 'Estradiol');
+    await _openIntakes($);
+    await _recordIntake($, scheduleName: 'Estradiol');
+    await $(ListTile).waitUntilVisible();
+
+    await $(ListTile).tap(); // -> EditIntakePage
+    await $(_editIntake).waitUntilVisible();
+
+    await $(_delete).tap(); // form's Delete button -> confirmation dialog
+    await $(AlertDialog).$(_delete).tap(); // confirm in the dialog
+
+    await $(_emptyIntakes).waitUntilVisible();
+    expect($(_emptyIntakes), findsOneWidget);
+    expect($(ListTile), findsNothing);
+  });
+}
+
+/// Launches the real app and waits for the home screen to be interactive.
+Future<void> _launchApp(PatrolIntegrationTester $) async {
+  app.main();
+  await $.pumpAndSettle();
+  // main() initialises asynchronously (timezone data, preferences) before
+  // runApp; poll until the home AppBar's settings button is on screen.
+  await $(Icons.settings).waitUntilVisible();
+}
+
+/// Switches from the Home tab to the Intakes tab via the bottom navigation bar.
+Future<void> _openIntakes(PatrolIntegrationTester $) async {
+  await $(_navIntakes).tap(); // NavigationDestination label
+}
+
+/// Seeds a minimal interval schedule (Estradiol + Oral) so an intake can be
+/// recorded against it, then returns to the Home tab. Mirrors the create flow
+/// covered by schedules_test.dart.
+Future<void> _seedSchedule(
+  PatrolIntegrationTester $, {
+  required String name,
+}) async {
+  await $(Icons.settings).tap(); // Home -> Settings
+  await $(_schedulesTile).scrollTo().tap(); // -> Schedules
+
+  await $(Icons.add).tap(); // FAB: "Add a schedule"
+  await $(TextField).containing(_nameLabel).enterText(name);
+  await $(DropdownButtonFormField<Molecule>).tap();
+  await $(_moleculeEstradiol).tap();
+  await $(DropdownButtonFormField<AdministrationRoute>).tap();
+  await $(_routeOral).tap();
+  await $(TextField).containing(_amountLabel).enterText('2'); // sets schedule dose
+  await $(_next).tap();
+
+  await $(_intervalToggle).tap();
+  await $(TextField).containing(_everyLabel).enterText('3');
+  await $(_save).tap();
+  await $(ListTile).containing(name).waitUntilVisible();
+
+  // Pop Schedules -> Settings -> Home so the bottom nav (and Intakes tab) is
+  // reachable again.
+  await $.tester.pageBack();
+  await $.pumpAndSettle();
+  await $.tester.pageBack();
+  await $.pumpAndSettle();
+}
+
+/// From the Intakes tab: FAB -> choose the schedule -> submit the intake form
+/// with its prefilled values (date = now, dose = schedule dose).
+Future<void> _recordIntake(
+  PatrolIntegrationTester $, {
+  required String scheduleName,
+}) async {
+  await $(Icons.add).tap(); // FAB: "Take an intake" -> ChooseSchedulePage
+  await $(scheduleName).tap(); // pick the schedule -> TakeMedicationPage
+  await $(_takeIntake).tap(); // submit, pops back to the intakes list
+}
+

--- a/integration_test/intakes_test.dart
+++ b/integration_test/intakes_test.dart
@@ -107,7 +107,8 @@ void main() {
     await $(ListTile).tap(); // -> EditIntakePage
     await $(_editIntake).waitUntilVisible();
 
-    await $(_editIntakeDelete).tap(); // form's Delete button -> confirmation dialog
+    await $(_editIntakeDelete)
+        .tap(); // form's Delete button -> confirmation dialog
     await $(_confirmDelete).tap(); // confirm in the dialog
 
     await $(_emptyIntakes).waitUntilVisible();
@@ -146,7 +147,9 @@ Future<void> _seedSchedule(
   await $(_moleculeEstradiol).tap();
   await $(DropdownButtonFormField<AdministrationRoute>).tap();
   await $(_routeOral).tap();
-  await $(TextField).containing(_amountLabel).enterText('2'); // sets schedule dose
+  await $(TextField)
+      .containing(_amountLabel)
+      .enterText('2'); // sets schedule dose
   await $(_next).tap();
 
   await $(_intervalToggle).tap();
@@ -172,4 +175,3 @@ Future<void> _recordIntake(
   await $(scheduleName).tap(); // pick the schedule (data, not localized)
   await $(_takeIntakeSubmit).tap(); // submit, pops back to the intakes list
 }
-

--- a/integration_test/schedules_test.dart
+++ b/integration_test/schedules_test.dart
@@ -1,9 +1,5 @@
 // Patrol E2E tests for the Medication Schedules feature.
-//
-// These run on a real Android device/emulator (Patrol does not support Linux
-// desktop), driving the actual app launched via `main()`. Run with:
-//   patrol test --target integration_test/schedules_test.dart --flavor standalone
-// See integration_test/README.md for the full setup and CI notes.
+// See integration_test/README.md for setup, running, state, and CI notes.
 //
 // Finder strategy: the schedules UI defines no widget Keys, so we target
 // fields by their decoration label (`$(TextField).containing('Name')`) rather

--- a/lib/ui/views/home/take_medication_page.dart
+++ b/lib/ui/views/home/take_medication_page.dart
@@ -184,6 +184,7 @@ class _TakeMedicationPageState extends State<TakeMedicationPage> {
           title: localizations.takeMedication(widget.schedule.name),
           avatar: widget.schedule.administrationRoute.icon,
           submitButtonLabel: localizations.takeIntake,
+          submitButtonKey: const ValueKey('takeIntakeSubmit'),
           isFormValid: _isFormValid,
           saveChanges: (!isLoading && _isFormValid)
               ? () => _takeIntake(medicationIntakeProvider, supplyItemProvider)

--- a/lib/ui/views/intakes/edit_intake_page.dart
+++ b/lib/ui/views/intakes/edit_intake_page.dart
@@ -201,6 +201,8 @@ class _EditIntakePageState extends State<EditIntakePage> {
           title: localizations.editIntake,
           avatar: widget.intake.administrationRoute.icon,
           submitButtonLabel: localizations.save,
+          submitButtonKey: const ValueKey('editIntakeSave'),
+          deleteButtonKey: const ValueKey('editIntakeDelete'),
           isFormValid: _isFormValid,
           saveChanges: (!isLoading && _isFormValid)
               ? () => _editIntake(medicationIntakeProvider, supplyItemProvider,
@@ -254,6 +256,7 @@ class _EditIntakePageState extends State<EditIntakePage> {
             FormTextField(
               controller: _notesController,
               label: localizations.notes,
+              fieldKey: const ValueKey('editIntakeNotes'),
               onChanged: _refresh,
               inputType: TextInputType.multiline,
               multiline: true,

--- a/lib/ui/views/main_page.dart
+++ b/lib/ui/views/main_page.dart
@@ -93,6 +93,7 @@ class _MainPageState extends State<MainPage> {
               destinations: [
                 for (final tab in tabs)
                   NavigationDestination(
+                    key: tab.navKey,
                     label: tab.title,
                     icon: Icon(tab.icon),
                     selectedIcon: Icon(tab.selectedIcon),

--- a/lib/ui/views/main_tab_config.dart
+++ b/lib/ui/views/main_tab_config.dart
@@ -8,6 +8,10 @@ class MainTabConfig {
   final List<Widget> Function(BuildContext context)? buildActions;
   final FloatingActionButton? Function(BuildContext context)? buildFab;
 
+  /// Key applied to the [BottomNavigationBarItem] corresponding to this tab
+  /// so e2e tests can target it without depending on its (localized) label.
+  final Key? navKey;
+
   const MainTabConfig({
     required this.title,
     required this.page,
@@ -15,5 +19,6 @@ class MainTabConfig {
     required this.selectedIcon,
     this.buildActions,
     this.buildFab,
+    this.navKey,
   });
 }

--- a/lib/ui/views/main_tabs.dart
+++ b/lib/ui/views/main_tabs.dart
@@ -36,6 +36,7 @@ List<MainTabConfig> getMainTabs(BuildContext context) {
       page: IntakesPage(),
       icon: Icons.event_outlined,
       selectedIcon: Icons.event_rounded,
+      navKey: const ValueKey('navTabIntakes'),
       buildFab: (context) => FloatingActionButton(
         tooltip: context.l10n.takeAnIntake,
         onPressed: () {

--- a/lib/ui/widgets/dialogs.dart
+++ b/lib/ui/widgets/dialogs.dart
@@ -24,6 +24,7 @@ class Dialogs {
               child: Text(cancel ?? l10n.cancel),
             ),
             TextButton(
+              key: const ValueKey('confirmDeleteConfirmButton'),
               onPressed: () => Navigator.of(context).pop(true),
               child: Text(confirm ?? l10n.delete,
                   style: TextStyle(color: Theme.of(context).colorScheme.error)),

--- a/lib/ui/widgets/forms/form_text_field.dart
+++ b/lib/ui/widgets/forms/form_text_field.dart
@@ -12,6 +12,10 @@ class FormTextField extends StatelessWidget {
   final String? errorText;
   final String? regexFormatter;
 
+  /// Key applied to the inner [TextField] (not the outer widget), so e2e tests
+  /// can target the input without depending on its (localized) label.
+  final Key? fieldKey;
+
   const FormTextField({
     super.key,
     required this.controller,
@@ -23,6 +27,7 @@ class FormTextField extends StatelessWidget {
     this.regexFormatter,
     this.readonly = false,
     this.multiline = false,
+    this.fieldKey,
   });
 
   @override
@@ -30,6 +35,7 @@ class FormTextField extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 8.0),
       child: TextField(
+        key: fieldKey,
         controller: controller,
         keyboardType: multiline ? TextInputType.multiline : inputType,
         inputFormatters: regexFormatter != null

--- a/lib/ui/widgets/forms/model_form.dart
+++ b/lib/ui/widgets/forms/model_form.dart
@@ -14,6 +14,11 @@ class ModelForm extends StatelessWidget {
   final VoidCallback saveChanges;
   final String submitButtonLabel;
 
+  /// Keys for the submit/delete buttons, so e2e tests can target them without
+  /// depending on the (localized) button labels.
+  final Key? submitButtonKey;
+  final Key? deleteButtonKey;
+
   const ModelForm({
     required this.title,
     this.avatar,
@@ -23,6 +28,8 @@ class ModelForm extends StatelessWidget {
     required this.isFormValid,
     required this.saveChanges,
     required this.submitButtonLabel,
+    this.submitButtonKey,
+    this.deleteButtonKey,
   });
 
   @override
@@ -75,6 +82,7 @@ class ModelForm extends StatelessWidget {
               if (onDelete != null) ...[
                 Expanded(
                   child: M3EButton.icon(
+                    key: deleteButtonKey,
                     onPressed: onDelete,
                     icon: const Icon(Icons.delete),
                     label: Text(context.l10n.delete),
@@ -93,6 +101,7 @@ class ModelForm extends StatelessWidget {
               Expanded(
                 child: onDelete != null
                     ? M3EButton.icon(
+                        key: submitButtonKey,
                         onPressed: isFormValid ? saveChanges : null,
                         icon: const Icon(Icons.save),
                         label: Text(submitButtonLabel),
@@ -100,6 +109,7 @@ class ModelForm extends StatelessWidget {
                         size: M3EButtonSize.md,
                       )
                     : M3EButton(
+                        key: submitButtonKey,
                         onPressed: isFormValid ? saveChanges : null,
                         style: M3EButtonStyle.filled,
                         size: M3EButtonSize.md,


### PR DESCRIPTION
### Description

Adds end-to-end (Patrol) test coverage for the **Intakes** feature, building on the existing Patrol setup. Five tests drive the real app the way a user would:

- empty state when no intakes exist
- "Add schedules first." prompt when recording with no schedule
- recording an intake from the Intakes tab
- editing an intake and persisting notes
- deleting an intake with confirmation

To make the tests resilient, this PR also introduces a **hybrid finder strategy**:
interactions are driven through stable widget `Key`s, while assertions still match on user-visible text (where that text *is* the behaviour under test). 
This decouples the interaction steps from the English copy and the device locale, and removes navigation-stack ambiguity when a pushed route leaves the previous one mounted.

The e2e README's "Writing tests" section now documents this hybrid strategy as the convention for new tests. `schedules_test.dart` remains text-based and can be migrated in a future PR.

All 5 intakes tests pass on a connected Android device.

Related to issue(s): #229 

### Type of change

- This change requires a documentation update
- Maintenance