### PR TITLE
fix(ci): stabilize flaky Patrol E2E job

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -69,7 +69,7 @@ jobs:
       # in pubspec.yaml. Omitting --target runs every *_test.dart under
       # integration_test/ (the test_directory in pubspec.yaml).
       - name: Run Patrol tests on emulator
-        timeout-minutes: 30
+        timeout-minutes: 45
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 34

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -80,7 +80,14 @@ jobs:
           heap-size: 1024M
           disable-animations: true
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
-          script: dart run patrol_cli:main test --flavor standalone --verbose
+          script: |
+            for attempt in 1 2 3; do
+              echo "::group::Patrol attempt $attempt"
+              dart run patrol_cli:main test --flavor standalone --verbose && exit 0
+              echo "::endgroup::"
+              echo "Patrol attempt $attempt failed (likely an instrumentation-process crash); retrying..."
+            done
+            exit 1
 
       - name: Upload Patrol results
         if: always()

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -76,7 +76,8 @@ jobs:
           target: google_apis
           arch: x86_64
           profile: pixel_6
-          ram-size: 4096M
+          ram-size: 6144M
+          heap-size: 1024M
           disable-animations: true
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
           script: dart run patrol_cli:main test --flavor standalone --verbose

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -76,18 +76,9 @@ jobs:
           target: google_apis
           arch: x86_64
           profile: pixel_6
-          ram-size: 6144M
-          heap-size: 1024M
           disable-animations: true
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
-          script: |
-            for attempt in 1 2 3; do
-              echo "::group::Patrol attempt $attempt"
-              dart run patrol_cli:main test --flavor standalone --verbose && exit 0
-              echo "::endgroup::"
-              echo "Patrol attempt $attempt failed (likely an instrumentation-process crash); retrying..."
-            done
-            exit 1
+          script: bash scripts/run_patrol_e2e.sh
 
       - name: Upload Patrol results
         if: always()

--- a/scripts/run_patrol_e2e.sh
+++ b/scripts/run_patrol_e2e.sh
@@ -4,15 +4,35 @@
 set -u
 
 ATTEMPTS="${PATROL_ATTEMPTS:-3}"
+ATTEMPT_TIMEOUT="${PATROL_ATTEMPT_TIMEOUT:-600}"
+
+# A crashed/wedged attempt can leave adb (and orphaned Gradle/instrumentation
+# processes) stuck; reset them so the next attempt starts from a clean device.
+reset_device_state() {
+  ./android/gradlew --stop >/dev/null 2>&1 || true
+  adb kill-server >/dev/null 2>&1 || true
+  adb start-server >/dev/null 2>&1 || true
+  adb wait-for-device >/dev/null 2>&1 || true
+}
 
 for attempt in $(seq 1 "$ATTEMPTS"); do
   echo "::group::Patrol attempt $attempt/$ATTEMPTS"
-  if dart run patrol_cli:main test --flavor standalone --verbose; then
-    echo "::endgroup::"
-    exit 0
-  fi
+  # Capture the exit code directly: `if timeout ...; then` would mask it, because
+  # an `if` whose condition is false and which has no `else` is itself status 0.
+  # --kill-after escalates to SIGKILL if patrol_cli ignores the initial SIGTERM.
+  timeout --kill-after=30s "$ATTEMPT_TIMEOUT" \
+    dart run patrol_cli:main test --flavor standalone --verbose
+  status=$?
   echo "::endgroup::"
-  echo "Patrol attempt $attempt/$ATTEMPTS failed (likely an instrumentation-process crash); retrying..."
+
+  if [ "$status" -eq 0 ]; then
+    exit 0
+  elif [ "$status" -eq 124 ]; then
+    echo "Patrol attempt $attempt/$ATTEMPTS wedged and was killed after ${ATTEMPT_TIMEOUT}s; retrying..."
+  else
+    echo "Patrol attempt $attempt/$ATTEMPTS failed (exit $status, likely an instrumentation-process crash); retrying..."
+  fi
+  reset_device_state
 done
 
 echo "Patrol failed after $ATTEMPTS attempts."

--- a/scripts/run_patrol_e2e.sh
+++ b/scripts/run_patrol_e2e.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Runs the Patrol Android E2E suite with retries.
+
+set -u
+
+ATTEMPTS="${PATROL_ATTEMPTS:-3}"
+
+for attempt in $(seq 1 "$ATTEMPTS"); do
+  echo "::group::Patrol attempt $attempt/$ATTEMPTS"
+  if dart run patrol_cli:main test --flavor standalone --verbose; then
+    echo "::endgroup::"
+    exit 0
+  fi
+  echo "::endgroup::"
+  echo "Patrol attempt $attempt/$ATTEMPTS failed (likely an instrumentation-process crash); retrying..."
+done
+
+echo "Patrol failed after $ATTEMPTS attempts."
+exit 1


### PR DESCRIPTION
### Description

The `CI - E2E (Patrol Android)` job failed intermittently, either "Expected 10 tests, received 9" or a silent ~30 min hang.

**Root cause:** Patrol runs each test in a fresh process (Test Orchestrator + `clearPackageData`), and that process sporadically dies (or wedges) at a test boundary before the app starts. It hits a different test each run, and every test that actually ran passed, so it's flaky infrastructure, not test logic.

**Fix :** retry the suite (`scripts/run_patrol_e2e.sh`):
- Up to 3 attempts; a passing attempt exits immediately (no cost on green runs).
- Per-attempt `timeout` turns a *wedge* into a fast retriable failure, with an adb/Gradle reset between attempts.
- Lives in a script file because `android-emulator-runner` splits inline `script:` per line and breaks multi-line shell.
- Bumped `timeout-minutes` 30 -> 45 so retries fit.

Verified in CI: attempt 1 crashed on one test, attempt 2 passed all 10 (~17 min).

### Type of change
- Bug fix (non-breaking change which fixes an issue)
- Maintenance
