### PR TITLE
Feat : Schedules e2e with keys

### DIFF
--- a/integration_test/schedules_test.dart
+++ b/integration_test/schedules_test.dart
@@ -13,11 +13,31 @@ import 'package:mona/data/model/molecule.dart';
 import 'package:mona/main.dart' as app;
 import 'package:patrol/patrol.dart';
 
-// English l10n strings exercised by these tests (see lib/l10n/app_en.arb).
+// Widget Keys on schedule interaction targets (must match the ValueKeys set in
+// the production widgets: settings_page.dart, new_schedule_*_page.dart,
+// edit_schedule/*.dart, and the shared model_form.dart / form_text_field.dart /
+// dialogs.dart).
+const _settingsSchedulesTile = ValueKey('settingsSchedulesTile');
+const _newScheduleName = ValueKey('newScheduleName');
+const _newScheduleAmount = ValueKey('newScheduleAmount');
+const _newScheduleNext = ValueKey('newScheduleNext');
+const _newScheduleSave = ValueKey('newScheduleSave');
+const _newScheduleEvery = ValueKey('newScheduleEvery');
+const _scheduleTypeInterval = ValueKey('scheduleTypeInterval');
+const _addNotificationTile = ValueKey('addNotificationTile');
+const _editScheduleInfoTile = ValueKey('editScheduleInfoTile');
+const _editScheduleName = ValueKey('editScheduleName');
+const _editScheduleSave = ValueKey('editScheduleSave');
+const _editScheduleDelete = ValueKey('editScheduleDelete');
+const _confirmDelete = ValueKey('confirmDeleteConfirmButton');
+
+// User-visible strings asserted by these tests (see lib/l10n/app_en.arb).
 const _emptyState = 'Add a schedule to get started.';
-const _schedulesTile = 'Schedules';
-const _nameLabel = 'Name';
-const _amountLabel = 'Amount';
+
+// Dropdown option labels: selected by their visible (localized) text. The
+// option lists come from shared enum dropdown builders used app-wide, so they
+// are not individually keyed; the dropdowns themselves are opened with a stable
+// typed finder ($(DropdownButtonFormField<Molecule>)).
 const _moleculeEstradiol = 'Estradiol';
 const _routeOral = 'Oral';
 const _next = 'Next';
@@ -34,11 +54,11 @@ void main() {
     await _openSchedules($);
     await _createIntervalSchedule($, name: 'To Delete');
 
-    await $(ListTile).containing('To Delete').tap();
-    await $(_editScheduleInfo).tap();
+    await $(ListTile).containing('To Delete').tap(); // data, not localized
+    await $(_editScheduleInfoTile).tap();
 
-    await $(_delete).tap(); // form's Delete button -> confirmation dialog
-    await $(AlertDialog).$(_delete).tap(); // confirm in the dialog
+    await $(_editScheduleDelete).tap(); // form's Delete button -> confirm dialog
+    await $(_confirmDelete).tap(); // confirm in the dialog
 
     await $(_emptyState).waitUntilVisible();
     expect($('To Delete'), findsNothing);
@@ -60,9 +80,9 @@ void main() {
     await $(Icons.add).tap(); // FAB: "Add a schedule"
     await _fillMainInfoAndNext($, name: 'Interval Estradiol');
 
-    await $(_intervalToggle).tap();
-    await $(TextField).containing(_everyLabel).enterText('3');
-    await $(_save).tap();
+    await $(_scheduleTypeInterval).tap();
+    await $(_newScheduleEvery).enterText('3');
+    await $(_newScheduleSave).tap();
 
     // provider.add() is fire-and-forget; wait for the list to rebuild.
     await $('Interval Estradiol').waitUntilVisible();
@@ -78,9 +98,9 @@ void main() {
 
     // "Every day" is the default type. Add one intake time via the time
     // picker (a daily schedule requires at least one time to be valid).
-    await $(_addNotification).tap();
-    await $('OK').tap(); // accept the default time
-    await $(_save).tap();
+    await $(_addNotificationTile).tap();
+    await $('OK').tap(); // accept the default time (Material time picker)
+    await $(_newScheduleSave).tap();
 
     await $('Daily Estradiol').waitUntilVisible();
     expect($('Daily Estradiol'), findsOneWidget);
@@ -92,9 +112,9 @@ void main() {
     await _createIntervalSchedule($, name: 'Old Name');
 
     await $(ListTile).containing('Old Name').tap(); // -> EditSchedulePage
-    await $(_editScheduleInfo).tap(); // -> EditScheduleMainInfoPage
-    await $(TextField).containing(_nameLabel).enterText('New Name');
-    await $(_save).tap(); // pops back to EditSchedulePage
+    await $(_editScheduleInfoTile).tap(); // -> EditScheduleMainInfoPage
+    await $(_editScheduleName).enterText('New Name');
+    await $(_editScheduleSave).tap(); // pops back to EditSchedulePage
 
     // Wait for the change to be reflected in the EditSchedulePage title before
     // navigating back, ensuring the provider update has finished.
@@ -119,7 +139,7 @@ Future<void> _launchApp(PatrolIntegrationTester $) async {
 /// Home -> Settings -> Schedules.
 Future<void> _openSchedules(PatrolIntegrationTester $) async {
   await $(Icons.settings).tap();
-  await $(_schedulesTile).scrollTo().tap();
+  await $(_settingsSchedulesTile).scrollTo().tap();
 }
 
 /// Fills the first create-schedule page (name, molecule, route, amount) with a
@@ -130,7 +150,7 @@ Future<void> _fillMainInfoAndNext(
   required String name,
   String dose = '2',
 }) async {
-  await $(TextField).containing(_nameLabel).enterText(name);
+  await $(_newScheduleName).enterText(name);
 
   await $(DropdownButtonFormField<Molecule>).tap();
   await $(_moleculeEstradiol).tap();
@@ -138,9 +158,9 @@ Future<void> _fillMainInfoAndNext(
   await $(DropdownButtonFormField<AdministrationRoute>).tap();
   await $(_routeOral).tap();
 
-  await $(TextField).containing(_amountLabel).enterText(dose);
+  await $(_newScheduleAmount).enterText(dose);
 
-  await $(_next).tap();
+  await $(_newScheduleNext).tap();
 }
 
 /// End-to-end helper: creates a minimal interval schedule and returns to the
@@ -151,8 +171,8 @@ Future<void> _createIntervalSchedule(
 }) async {
   await $(Icons.add).tap();
   await _fillMainInfoAndNext($, name: name);
-  await $(_intervalToggle).tap();
-  await $(TextField).containing(_everyLabel).enterText('3');
-  await $(_save).tap();
+  await $(_scheduleTypeInterval).tap();
+  await $(_newScheduleEvery).enterText('3');
+  await $(_newScheduleSave).tap();
   await $(ListTile).containing(name).waitUntilVisible();
 }

--- a/integration_test/schedules_test.dart
+++ b/integration_test/schedules_test.dart
@@ -34,13 +34,6 @@ const _emptyState = 'Add a schedule to get started.';
 // typed finder ($(DropdownButtonFormField<Molecule>)).
 const _moleculeEstradiol = 'Estradiol';
 const _routeOral = 'Oral';
-const _next = 'Next';
-const _save = 'Save';
-const _intervalToggle = 'Interval';
-const _everyLabel = 'Every';
-const _addNotification = 'Add a time';
-const _editScheduleInfo = 'Edit schedule info';
-const _delete = 'Delete';
 
 void main() {
   patrolTest('deletes a schedule with confirmation', ($) async {
@@ -51,7 +44,8 @@ void main() {
     await $(ListTile).containing('To Delete').tap(); // data, not localized
     await $(_editScheduleInfoTile).tap();
 
-    await $(_editScheduleDelete).tap(); // form's Delete button -> confirm dialog
+    await $(_editScheduleDelete)
+        .tap(); // form's Delete button -> confirm dialog
     await $(_confirmDelete).tap(); // confirm in the dialog
 
     await $(_emptyState).waitUntilVisible();

--- a/integration_test/schedules_test.dart
+++ b/integration_test/schedules_test.dart
@@ -1,10 +1,4 @@
 // Patrol E2E tests for the Medication Schedules feature.
-// See integration_test/README.md for setup, running, state, and CI notes.
-//
-// Finder strategy: the schedules UI defines no widget Keys, so we target
-// fields by their decoration label (`$(TextField).containing('Name')`) rather
-// than by index — pushed routes stay mounted underneath, so index-based
-// TextField finders would be ambiguous across the navigation stack.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/lib/ui/views/home/settings/schedules/edit_schedule/edit_schedule_main_info.dart
+++ b/lib/ui/views/home/settings/schedules/edit_schedule/edit_schedule_main_info.dart
@@ -154,6 +154,8 @@ class _EditScheduleMainInfoPageState extends State<EditScheduleMainInfoPage> {
     return ModelForm(
       title: localizations.editSchedule,
       submitButtonLabel: localizations.save,
+      submitButtonKey: const ValueKey('editScheduleSave'),
+      deleteButtonKey: const ValueKey('editScheduleDelete'),
       isFormValid: _isFormValid,
       saveChanges: _saveSchedule,
       onDelete: _confirmDelete,
@@ -161,6 +163,7 @@ class _EditScheduleMainInfoPageState extends State<EditScheduleMainInfoPage> {
         FormTextField(
           controller: _nameController,
           label: localizations.name,
+          fieldKey: const ValueKey('editScheduleName'),
           onChanged: _refresh,
           inputType: TextInputType.text,
           errorText: _nameError,

--- a/lib/ui/views/home/settings/schedules/edit_schedule/edit_schedule_page.dart
+++ b/lib/ui/views/home/settings/schedules/edit_schedule/edit_schedule_page.dart
@@ -35,6 +35,7 @@ class EditSchedulePage extends StatelessWidget {
       body: ListView(
         children: [
           ListTile(
+            key: const ValueKey('editScheduleInfoTile'),
             title: Text(localizations.editScheduleInfo),
             subtitle: Text(currentSchedule.localizedSummary(localizations)),
             trailing: Icon(Icons.chevron_right),

--- a/lib/ui/views/home/settings/schedules/new_schedule_main_info_page.dart
+++ b/lib/ui/views/home/settings/schedules/new_schedule_main_info_page.dart
@@ -134,6 +134,7 @@ class _NewScheduleMainInfoPageState extends State<NewScheduleMainInfoPage> {
     return ModelForm(
       title: localizations.newSchedule,
       submitButtonLabel: localizations.next,
+      submitButtonKey: const ValueKey('newScheduleNext'),
       isFormValid: _isFormValid,
       saveChanges: _next,
       avatar: Symbols.prescriptions,
@@ -141,6 +142,7 @@ class _NewScheduleMainInfoPageState extends State<NewScheduleMainInfoPage> {
         FormTextField(
           controller: _nameController,
           label: localizations.name,
+          fieldKey: const ValueKey('newScheduleName'),
           onChanged: _refresh,
           inputType: TextInputType.text,
         ),
@@ -171,6 +173,7 @@ class _NewScheduleMainInfoPageState extends State<NewScheduleMainInfoPage> {
         FormTextField(
           controller: _doseController,
           label: localizations.amount,
+          fieldKey: const ValueKey('newScheduleAmount'),
           suffixText: _molecule?.unit,
           onChanged: _refresh,
           inputType: TextInputType.numberWithOptions(decimal: true),

--- a/lib/ui/views/home/settings/schedules/new_schedule_scheduling_page.dart
+++ b/lib/ui/views/home/settings/schedules/new_schedule_scheduling_page.dart
@@ -175,6 +175,7 @@ class _NewScheduleSchedulingPageState extends State<NewScheduleSchedulingPage> {
     return ModelForm(
       title: widget.name,
       submitButtonLabel: l10n.save,
+      submitButtonKey: const ValueKey('newScheduleSave'),
       isFormValid: _isFormValid,
       saveChanges: _save,
       closeAll: _closeAll,
@@ -225,6 +226,7 @@ class _NewScheduleSchedulingPageState extends State<NewScheduleSchedulingPage> {
       FormTextField(
         controller: _intervalDaysController,
         label: l10n.every,
+        fieldKey: const ValueKey('newScheduleEvery'),
         suffixText: l10n.days,
         onChanged: _refresh,
         inputType: TextInputType.number,

--- a/lib/ui/views/home/settings/schedules/new_schedule_scheduling_page.dart
+++ b/lib/ui/views/home/settings/schedules/new_schedule_scheduling_page.dart
@@ -214,7 +214,12 @@ class _NewScheduleSchedulingPageState extends State<NewScheduleSchedulingPage> {
       },
       actions: [
         M3EToggleButtonGroupAction(label: Text(l10n.scheduleFrequencyDaily)),
-        M3EToggleButtonGroupAction(label: Text(l10n.scheduleFrequencyInterval)),
+        M3EToggleButtonGroupAction(
+          label: Text(
+            l10n.scheduleFrequencyInterval,
+            key: const ValueKey('scheduleTypeInterval'),
+          ),
+        ),
         M3EToggleButtonGroupAction(label: Text(l10n.scheduleFrequencyWeekly)),
       ],
     );
@@ -251,6 +256,7 @@ class _NewScheduleSchedulingPageState extends State<NewScheduleSchedulingPage> {
         times: _intakeOrNotificationTimes,
         rowIcon: widget.administrationRoute.icon,
         addLabel: l10n.addIntakeTime,
+        addTileKey: const ValueKey('addNotificationTile'),
         onAdd: _addTime,
         onEdit: _editTime,
         onDelete: _deleteTime,

--- a/lib/ui/views/home/settings/settings_page.dart
+++ b/lib/ui/views/home/settings/settings_page.dart
@@ -196,6 +196,7 @@ class _SettingsPageState extends State<SettingsPage>
             ),
           ),
           ListTile(
+            key: const ValueKey('settingsSchedulesTile'),
             title: Text(localizations.schedules),
             subtitle: Text(medicationScheduleProvider.schedules.isEmpty
                 ? localizations.noSchedules

--- a/lib/ui/widgets/time_list_card.dart
+++ b/lib/ui/widgets/time_list_card.dart
@@ -9,6 +9,7 @@ class TimeListCard extends StatelessWidget {
   final ValueChanged<int> onEdit;
   final ValueChanged<int> onDelete;
   final List<Widget> trailingChildren;
+  final Key? addTileKey;
 
   const TimeListCard({
     super.key,
@@ -19,6 +20,7 @@ class TimeListCard extends StatelessWidget {
     required this.onEdit,
     required this.onDelete,
     this.trailingChildren = const [],
+    this.addTileKey,
   });
 
   @override
@@ -41,6 +43,7 @@ class TimeListCard extends StatelessWidget {
             ),
           ),
         ListTile(
+          key: addTileKey,
           leading: const Icon(Icons.add),
           title: Text(addLabel),
           onTap: onAdd,

--- a/scripts/run_patrol_e2e.sh
+++ b/scripts/run_patrol_e2e.sh
@@ -21,7 +21,7 @@ for attempt in $(seq 1 "$ATTEMPTS"); do
   # an `if` whose condition is false and which has no `else` is itself status 0.
   # --kill-after escalates to SIGKILL if patrol_cli ignores the initial SIGTERM.
   timeout --kill-after=30s "$ATTEMPT_TIMEOUT" \
-    dart run patrol_cli:main test --flavor standalone --verbose
+    dart run patrol_cli:main test --flavor standalone
   status=$?
   echo "::endgroup::"
 


### PR DESCRIPTION
### Description

Schedule E2E (Patrol) tests now target UI by stable widget `ValueKey`s instead of localized labels and navigation-stack index, which were brittle. Added keys to the relevant settings, new-schedule, and edit-schedule widgets and updated the tests to use them.

Related to issue(s): #229 

### Type of change

- Maintenance