### PR TITLE
CI: Stabilize Patrol E2E

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -10,9 +10,19 @@ on:
 
 jobs:
   e2e_android:
-    name: Patrol Android
+    name: Patrol Android (${{ matrix.shard }})
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    strategy:
+      # One shard per test file: a flaky file only retries itself, the shards
+      # run in parallel, and failures are isolated per file in the checks UI.
+      fail-fast: false
+      matrix:
+        include:
+          - shard: intakes
+            test_file: integration_test/intakes_test.dart
+          - shard: schedules
+            test_file: integration_test/schedules_test.dart
 
     steps:
       - name: Checkout repository
@@ -92,13 +102,15 @@ jobs:
       # The app builds debug with applicationIdSuffix ".dev" (see
       # android/app/build.gradle), so the installed package under test is
       # com.deliacheminot.mona.dev — already set as patrol.android.package_name
-      # in pubspec.yaml. Omitting --target runs every *_test.dart under
-      # integration_test/ (the test_directory in pubspec.yaml).
+      # in pubspec.yaml. PATROL_TARGET selects this shard's single test file;
+      # run_patrol_e2e.sh passes it to `patrol test --target`.
       #
       # force-avd-creation: false reuses the cached AVD
       - name: Run Patrol tests on emulator
         timeout-minutes: 45
         uses: reactivecircus/android-emulator-runner@v2
+        env:
+          PATROL_TARGET: ${{ matrix.test_file }}
         with:
           api-level: 34
           target: google_apis
@@ -113,7 +125,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: patrol-results
+          name: patrol-results-${{ matrix.shard }}
           path: |
             build/app/outputs/androidTest-results/
             build/app/reports/

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -63,11 +63,39 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
+      # Cache the AVD and a warm boot snapshot so the emulator loads from a saved
+      # state instead of cold-booting on every run
+      - name: Cache AVD snapshot
+        uses: actions/cache@v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-api34-google_apis-x86_64-pixel_6
+
+      # On a cache miss, boot the emulator once with snapshot-save enabled and
+      # immediately exit. Skipped entirely on a cache hit.
+      - name: Create AVD snapshot
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          target: google_apis
+          arch: x86_64
+          profile: pixel_6
+          force-avd-creation: false
+          disable-animations: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          script: echo "AVD snapshot generated."
+
       # The app builds debug with applicationIdSuffix ".dev" (see
       # android/app/build.gradle), so the installed package under test is
       # com.deliacheminot.mona.dev — already set as patrol.android.package_name
       # in pubspec.yaml. Omitting --target runs every *_test.dart under
       # integration_test/ (the test_directory in pubspec.yaml).
+      #
+      # force-avd-creation: false reuses the cached AVD
       - name: Run Patrol tests on emulator
         timeout-minutes: 45
         uses: reactivecircus/android-emulator-runner@v2
@@ -76,8 +104,9 @@ jobs:
           target: google_apis
           arch: x86_64
           profile: pixel_6
+          force-avd-creation: false
           disable-animations: true
-          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
+          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot-save -noaudio -no-boot-anim
           script: bash scripts/run_patrol_e2e.sh
 
       - name: Upload Patrol results

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -28,6 +28,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      # ubuntu-latest ships ~30 GB of toolchains we don't use (.NET, Haskell,
+      # etc.). The Android system-image install + AVD snapshot can exhaust the
+      # remaining disk ("No space left on device"), failing the emulator before
+      # our test script even runs. Reclaim the unused space, but KEEP the Android
+      # SDK and the Flutter/Java tool-cache the next steps depend on.
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          android: false
+          tool-cache: false
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: true
+
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -9,20 +9,40 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Discover the test files at runtime and emit a JSON matrix, so new
+  # integration_test/*_test.dart files are picked up automatically.
+  # `shard` is the file name minus `_test.dart`
+  discover:
+    name: Discover test files
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.find.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Build test matrix
+        id: find
+        run: |
+          matrix=$(find integration_test -name '*_test.dart' -printf '%f\t%p\n' | sort \
+            | jq -R -s -c '
+                split("\n") | map(select(length > 0)) | map(split("\t"))
+                | { include: map({ shard: (.[0] | sub("_test\\.dart$"; "")), test_file: .[1] }) }')
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "Discovered matrix: $matrix"
+
   e2e_android:
     name: Patrol Android (${{ matrix.shard }})
+    needs: discover
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
-      # One shard per test file: a flaky file only retries itself, the shards
-      # run in parallel, and failures are isolated per file in the checks UI.
+      # One shard per discovered test file: a flaky file only retries itself,
+      # the shards run in parallel, and failures are isolated per file in the
+      # checks UI. max-parallel bounds how many emulators boot at once so a large
+      # suite doesn't overwhelm the runner pool.
       fail-fast: false
-      matrix:
-        include:
-          - shard: intakes
-            test_file: integration_test/intakes_test.dart
-          - shard: schedules
-            test_file: integration_test/schedules_test.dart
+      max-parallel: 4
+      matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
 
     steps:
       - name: Checkout repository

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -126,6 +126,9 @@ of its CI options, so a few things mitigate that:
   parallel. **When you add a test file, add a matching entry to the `matrix`.**
 - **Retries with device reset.** [`run_patrol_e2e.sh`](../scripts/run_patrol_e2e.sh)
   retries a wedged/crashed attempt after resetting adb + Gradle.
+- **Disk cleanup.** A `free-disk-space` step reclaims unused runner toolchains
+  (keeping the Android SDK + Flutter/Java) so the system-image install and AVD
+  snapshot don't hit "No space left on device".
 
 ### Follow-up: Test Butler (only if flakiness persists)
 

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -121,9 +121,11 @@ of its CI options, so a few things mitigate that:
 
 - **AVD snapshot caching.** The emulator loads a cached warm boot snapshot
   instead of cold-booting every run.
-- **Per-file matrix.** Each `*_test.dart` runs as its own shard
-  (`PATROL_TARGET`), so a flaky file only retries itself and the shards run in
-  parallel. **When you add a test file, add a matching entry to the `matrix`.**
+- **Per-file matrix (auto-discovered).** A `discover` job globs
+  `integration_test/*_test.dart` and emits the matrix, so **new test files are
+  picked up automatically — no workflow edit needed.** Each file runs as its own
+  shard (`PATROL_TARGET`), so a flaky file only retries itself and shards run in
+  parallel (bounded by `max-parallel`).
 - **Retries with device reset.** [`run_patrol_e2e.sh`](../scripts/run_patrol_e2e.sh)
   retries a wedged/crashed attempt after resetting adb + Gradle.
 - **Disk cleanup.** A `free-disk-space` step reclaims unused runner toolchains

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -130,19 +130,6 @@ of its CI options, so a few things mitigate that:
   (keeping the Android SDK + Flutter/Java) so the system-image install and AVD
   snapshot don't hit "No space left on device".
 
-### Follow-up: Test Butler (only if flakiness persists)
-
-[Test Butler](https://github.com/linkedin/test-butler) stabilizes the emulator
-(suppresses system crash/ANR dialogs, keeps the device awake, locks system
-state) — which targets exactly the "wedged / instrumentation-process crash"
-failures the retry loop absorbs. Its main restriction, **no Google Play
-Services**, does *not* affect Mona (the app has no GMS/Firebase deps and CI
-already uses the `google_apis` image, not `google_apis_playstore`).
-
-It's deliberately **not** wired up yet: it adds a runtime dependency and needs
-its API-34 compatibility plus interaction with Patrol's mandatory
-`PatrolJUnitRunner` verified. Add it only if wedge/crash flakiness persists
-*after* the snapshot caching + matrix changes, so there's a clean before/after.
 
 ## iOS (follow-up - not yet wired)
 

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -113,6 +113,34 @@ When adding keys, prefer threading an optional key param through the shared
 widgets (`ModelForm`, `FormTextField`, `Dialogs`, `MainTabConfig`) so other
 features can reuse them; the params are optional and backward-compatible.
 
+## CI (Android emulator)
+
+[`ci-e2e.yml`](../.github/workflows/ci-e2e.yml) runs the suite on a
+KVM-accelerated emulator. Patrol's emulator path is inherently the least stable
+of its CI options, so a few things mitigate that:
+
+- **AVD snapshot caching.** The emulator loads a cached warm boot snapshot
+  instead of cold-booting every run.
+- **Per-file matrix.** Each `*_test.dart` runs as its own shard
+  (`PATROL_TARGET`), so a flaky file only retries itself and the shards run in
+  parallel. **When you add a test file, add a matching entry to the `matrix`.**
+- **Retries with device reset.** [`run_patrol_e2e.sh`](../scripts/run_patrol_e2e.sh)
+  retries a wedged/crashed attempt after resetting adb + Gradle.
+
+### Follow-up: Test Butler (only if flakiness persists)
+
+[Test Butler](https://github.com/linkedin/test-butler) stabilizes the emulator
+(suppresses system crash/ANR dialogs, keeps the device awake, locks system
+state) — which targets exactly the "wedged / instrumentation-process crash"
+failures the retry loop absorbs. Its main restriction, **no Google Play
+Services**, does *not* affect Mona (the app has no GMS/Firebase deps and CI
+already uses the `google_apis` image, not `google_apis_playstore`).
+
+It's deliberately **not** wired up yet: it adds a runtime dependency and needs
+its API-34 compatibility plus interaction with Patrol's mandatory
+`PatrolJUnitRunner` verified. Add it only if wedge/crash flakiness persists
+*after* the snapshot caching + matrix changes, so there's a clean before/after.
+
 ## iOS (follow-up - not yet wired)
 
 The chosen target is Android-in-CI, and iOS requires Xcode project changes that

--- a/scripts/run_patrol_e2e.sh
+++ b/scripts/run_patrol_e2e.sh
@@ -1,10 +1,22 @@
 #!/bin/bash
 # Runs the Patrol Android E2E suite with retries.
+#
+# PATROL_TARGET (optional): a single integration_test/*_test.dart file to run.
+# The CI matrix sets this so each shard runs one file; when unset, Patrol runs
+# every test under the configured test_directory.
 
 set -u
 
 ATTEMPTS="${PATROL_ATTEMPTS:-3}"
 ATTEMPT_TIMEOUT="${PATROL_ATTEMPT_TIMEOUT:-600}"
+
+# Build the optional --target flag as an array so an unset target expands to
+# nothing rather than an empty argument that Patrol would try to parse.
+target_args=()
+if [ -n "${PATROL_TARGET:-}" ]; then
+  target_args=(--target "$PATROL_TARGET")
+  echo "Targeting single test file: $PATROL_TARGET"
+fi
 
 # A crashed/wedged attempt can leave adb (and orphaned Gradle/instrumentation
 # processes) stuck; reset them so the next attempt starts from a clean device.
@@ -21,7 +33,7 @@ for attempt in $(seq 1 "$ATTEMPTS"); do
   # an `if` whose condition is false and which has no `else` is itself status 0.
   # --kill-after escalates to SIGKILL if patrol_cli ignores the initial SIGTERM.
   timeout --kill-after=30s "$ATTEMPT_TIMEOUT" \
-    dart run patrol_cli:main test --flavor standalone --verbose
+    dart run patrol_cli:main test --flavor standalone ${target_args[@]+"${target_args[@]}"}
   status=$?
   echo "::endgroup::"
 


### PR DESCRIPTION
### Description

The Patrol E2E pipeline (build -> boot Android emulator -> run with retries) has been a fragile, slow part of CI. This reduces both the flakiness and the per-run cost without changing what the tests assert:

- **AVD snapshot caching** : The emulator now loads a cached warm boot snapshot instead of cold-booting on every run (~1–2 min saved per run). The cache key pins the exact device config so it rebuilds automatically if any of those change.

- **Per-file test matrix** : Each `integration_test/*_test.dart` runs as its own shard (`fail-fast: false`), so a flaky file only retries itself, shards run in parallel, and failures are isolated per file in the checks UI. `run_patrol_e2e.sh` takes an optional `PATROL_TARGET` to scope a run to one file, Results upload under a per-shard artifact name.

- **Disk cleanup** : A new `free-disk-space` step reclaims unused runner toolchains so the runner doesn't hit "No space left on device".

Related to issue(s): #229 

### Type of change
- Maintenance

### Screenshot
from this : 
<img width="693" height="258" alt="image" src="https://github.com/user-attachments/assets/f4ccf3c0-c5e3-4cbf-9d57-740a1527738a" />

... to this :
<img width="789" height="334" alt="image" src="https://github.com/user-attachments/assets/42c4c40b-0549-47a3-90b2-0b900f53f271" />

