### PR TITLE
fix: reveresed version numbers in update dialog

### DIFF
--- a/lib/services/update_service.dart
+++ b/lib/services/update_service.dart
@@ -111,7 +111,7 @@ class UpdateService {
       context: context,
       builder: (dialogContext) => AlertDialog(
         title: Text(l10n.updateDialogTitle),
-        content: Text(l10n.updateDialogBody(latest, current)),
+        content: Text(l10n.updateDialogBody(current, latest)),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(dialogContext),


### PR DESCRIPTION
### Description
The standalone updater dialog displays the version numbers swapped, indicating the current version as the new one and the new version as the one installed. This fixes it by reordering the arguments correctly.

Related to issue(s): none

### Type of change
- Bug fix (non-breaking change which fixes an issue)
