### PR TITLE
feat: e2e supplies

### DIFF
--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -98,10 +98,11 @@ the production code, and keep **assertions** matching on user-visible text.
   can be ambiguous when a pushed route leaves the previous one mounted
   underneath. A `ValueKey` on the production widget avoids all three. Declare
   the keys as `const ValueKey(...)` at the top of the test file, matching the
-  ones set in `lib/ui/...`. For widgets reused across routes (e.g. a form's
-  submit button), pass a **page-specific** key rather than one shared key -
-  pushed routes stay mounted, so a single key would be ambiguous across the
-  navigation stack.
+  ones set in `lib/ui/...` - the production side of any key is a
+  `grep -r "'theKeyString'" lib` away, so the test files don't list them. For
+  widgets reused across routes (e.g. a form's submit button), pass a
+  **page-specific** key rather than one shared key - pushed routes stay mounted,
+  so a single key would be ambiguous across the navigation stack.
 - **Assertions : visible text.** When the displayed copy *is* the behaviour
   under test (empty states, dialog titles, persisted values), assert on the
   text directly (`$('Taken intakes will appear here')`). A key there would

--- a/integration_test/intakes_test.dart
+++ b/integration_test/intakes_test.dart
@@ -7,9 +7,8 @@ import 'package:mona/data/model/molecule.dart';
 import 'package:mona/main.dart' as app;
 import 'package:patrol/patrol.dart';
 
-// Widget Keys on intake interaction targets (must match the ValueKeys set in
-// the production widgets: main_tabs.dart, model_form.dart, form_text_field.dart,
-// dialogs.dart).
+// Keys for interaction targets, mirroring the ValueKeys set on the production
+// widgets under lib/ui/.
 const _navTabIntakes = ValueKey('navTabIntakes');
 const _takeIntakeSubmit = ValueKey('takeIntakeSubmit');
 const _editIntakeSave = ValueKey('editIntakeSave');

--- a/integration_test/intakes_test.dart
+++ b/integration_test/intakes_test.dart
@@ -4,17 +4,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mona/data/model/administration_route.dart';
 import 'package:mona/data/model/molecule.dart';
-import 'package:mona/main.dart' as app;
 import 'package:patrol/patrol.dart';
+
+import 'support/helpers.dart';
 
 // Keys for interaction targets, mirroring the ValueKeys set on the production
 // widgets under lib/ui/.
-const _navTabIntakes = ValueKey('navTabIntakes');
 const _takeIntakeSubmit = ValueKey('takeIntakeSubmit');
 const _editIntakeSave = ValueKey('editIntakeSave');
 const _editIntakeDelete = ValueKey('editIntakeDelete');
 const _editIntakeNotes = ValueKey('editIntakeNotes');
-const _confirmDelete = ValueKey('confirmDeleteConfirmButton');
 
 const _emptyIntakes = 'Taken intakes will appear here';
 const _addSchedulesFirst = 'Add schedules first.';
@@ -32,8 +31,8 @@ const _everyLabel = 'Every';
 
 void main() {
   patrolTest('shows empty state when there are no intakes', ($) async {
-    await _launchApp($);
-    await _openIntakes($);
+    await $.launchApp();
+    await $.openIntakes();
 
     await $(_emptyIntakes).waitUntilVisible();
     expect($(_emptyIntakes), findsOneWidget);
@@ -42,8 +41,8 @@ void main() {
   patrolTest('prompts to add a schedule when none exist', ($) async {
     // With no schedules, the record-intake entry view (ChooseSchedulePage)
     // shows a prompt instead of a selectable schedule list.
-    await _launchApp($);
-    await _openIntakes($);
+    await $.launchApp();
+    await $.openIntakes();
 
     await $(Icons.add).tap(); // FAB: "Take an intake" -> ChooseSchedulePage
     await $(_addSchedulesFirst).waitUntilVisible();
@@ -51,9 +50,9 @@ void main() {
   });
 
   patrolTest('records an intake from the intakes tab', ($) async {
-    await _launchApp($);
+    await $.launchApp();
     await _seedSchedule($, name: 'Estradiol');
-    await _openIntakes($);
+    await $.openIntakes();
 
     await _recordIntake($, scheduleName: 'Estradiol');
 
@@ -65,9 +64,9 @@ void main() {
   });
 
   patrolTest('edits an intake and persists notes', ($) async {
-    await _launchApp($);
+    await $.launchApp();
     await _seedSchedule($, name: 'Estradiol');
-    await _openIntakes($);
+    await $.openIntakes();
     await _recordIntake($, scheduleName: 'Estradiol');
     await $(ListTile).waitUntilVisible();
 
@@ -83,9 +82,9 @@ void main() {
   });
 
   patrolTest('deletes an intake with confirmation', ($) async {
-    await _launchApp($);
+    await $.launchApp();
     await _seedSchedule($, name: 'Estradiol');
-    await _openIntakes($);
+    await $.openIntakes();
     await _recordIntake($, scheduleName: 'Estradiol');
     await $(ListTile).waitUntilVisible();
 
@@ -94,26 +93,12 @@ void main() {
 
     await $(_editIntakeDelete)
         .tap(); // form's Delete button -> confirmation dialog
-    await $(_confirmDelete).tap(); // confirm in the dialog
+    await $(confirmDeleteButton).tap(); // confirm in the dialog
 
     await $(_emptyIntakes).waitUntilVisible();
     expect($(_emptyIntakes), findsOneWidget);
     expect($(ListTile), findsNothing);
   });
-}
-
-/// Launches the real app and waits for the home screen to be interactive.
-Future<void> _launchApp(PatrolIntegrationTester $) async {
-  app.main();
-  await $.pumpAndSettle();
-  // main() initialises asynchronously (timezone data, preferences) before
-  // runApp; poll until the home AppBar's settings button is on screen.
-  await $(Icons.settings).waitUntilVisible();
-}
-
-/// Switches from the Home tab to the Intakes tab via the bottom navigation bar.
-Future<void> _openIntakes(PatrolIntegrationTester $) async {
-  await $(_navTabIntakes).tap(); // keyed NavigationDestination
 }
 
 /// Seeds a minimal interval schedule (Estradiol + Oral) so an intake can be

--- a/integration_test/schedules_test.dart
+++ b/integration_test/schedules_test.dart
@@ -4,12 +4,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mona/data/model/administration_route.dart';
 import 'package:mona/data/model/molecule.dart';
-import 'package:mona/main.dart' as app;
 import 'package:patrol/patrol.dart';
+
+import 'support/helpers.dart';
 
 // Keys for interaction targets, mirroring the ValueKeys set on the production
 // widgets under lib/ui/.
-const _settingsSchedulesTile = ValueKey('settingsSchedulesTile');
 const _newScheduleName = ValueKey('newScheduleName');
 const _newScheduleAmount = ValueKey('newScheduleAmount');
 const _newScheduleNext = ValueKey('newScheduleNext');
@@ -21,7 +21,6 @@ const _editScheduleInfoTile = ValueKey('editScheduleInfoTile');
 const _editScheduleName = ValueKey('editScheduleName');
 const _editScheduleSave = ValueKey('editScheduleSave');
 const _editScheduleDelete = ValueKey('editScheduleDelete');
-const _confirmDelete = ValueKey('confirmDeleteConfirmButton');
 
 // User-visible strings asserted by these tests (see lib/l10n/app_en.arb).
 const _emptyState = 'Add a schedule to get started.';
@@ -35,8 +34,8 @@ const _routeOral = 'Oral';
 
 void main() {
   patrolTest('deletes a schedule with confirmation', ($) async {
-    await _launchApp($);
-    await _openSchedules($);
+    await $.launchApp();
+    await $.openSchedules();
     await _createIntervalSchedule($, name: 'To Delete');
 
     await $(ListTile).containing('To Delete').tap(); // data, not localized
@@ -44,7 +43,7 @@ void main() {
 
     await $(_editScheduleDelete)
         .tap(); // form's Delete button -> confirm dialog
-    await $(_confirmDelete).tap(); // confirm in the dialog
+    await $(confirmDeleteButton).tap(); // confirm in the dialog
 
     await $(_emptyState).waitUntilVisible();
     expect($('To Delete'), findsNothing);
@@ -52,16 +51,16 @@ void main() {
   });
 
   patrolTest('shows empty state when there are no schedules', ($) async {
-    await _launchApp($);
-    await _openSchedules($);
+    await $.launchApp();
+    await $.openSchedules();
 
     await $(_emptyState).waitUntilVisible();
     expect($(_emptyState), findsOneWidget);
   });
 
   patrolTest('creates an interval schedule', ($) async {
-    await _launchApp($);
-    await _openSchedules($);
+    await $.launchApp();
+    await $.openSchedules();
 
     await $(Icons.add).tap(); // FAB: "Add a schedule"
     await _fillMainInfoAndNext($, name: 'Interval Estradiol');
@@ -76,8 +75,8 @@ void main() {
   });
 
   patrolTest('creates a daily schedule', ($) async {
-    await _launchApp($);
-    await _openSchedules($);
+    await $.launchApp();
+    await $.openSchedules();
 
     await $(Icons.add).tap();
     await _fillMainInfoAndNext($, name: 'Daily Estradiol');
@@ -93,8 +92,8 @@ void main() {
   });
 
   patrolTest('edits a schedule name', ($) async {
-    await _launchApp($);
-    await _openSchedules($);
+    await $.launchApp();
+    await $.openSchedules();
     await _createIntervalSchedule($, name: 'Old Name');
 
     await $(ListTile).containing('Old Name').tap(); // -> EditSchedulePage
@@ -111,21 +110,6 @@ void main() {
     expect($('New Name'), findsOneWidget);
     expect($('Old Name'), findsNothing);
   });
-}
-
-/// Launches the real app and waits for the home screen to be interactive.
-Future<void> _launchApp(PatrolIntegrationTester $) async {
-  app.main();
-  await $.pumpAndSettle();
-  // main() initialises asynchronously (timezone data, preferences) before
-  // runApp; poll until the home AppBar's settings button is on screen.
-  await $(Icons.settings).waitUntilVisible();
-}
-
-/// Home -> Settings -> Schedules.
-Future<void> _openSchedules(PatrolIntegrationTester $) async {
-  await $(Icons.settings).tap();
-  await $(_settingsSchedulesTile).scrollTo().tap();
 }
 
 /// Fills the first create-schedule page (name, molecule, route, amount) with a

--- a/integration_test/schedules_test.dart
+++ b/integration_test/schedules_test.dart
@@ -7,10 +7,8 @@ import 'package:mona/data/model/molecule.dart';
 import 'package:mona/main.dart' as app;
 import 'package:patrol/patrol.dart';
 
-// Widget Keys on schedule interaction targets (must match the ValueKeys set in
-// the production widgets: settings_page.dart, new_schedule_*_page.dart,
-// edit_schedule/*.dart, and the shared model_form.dart / form_text_field.dart /
-// dialogs.dart).
+// Keys for interaction targets, mirroring the ValueKeys set on the production
+// widgets under lib/ui/.
 const _settingsSchedulesTile = ValueKey('settingsSchedulesTile');
 const _newScheduleName = ValueKey('newScheduleName');
 const _newScheduleAmount = ValueKey('newScheduleAmount');

--- a/integration_test/supplies_test.dart
+++ b/integration_test/supplies_test.dart
@@ -1,0 +1,161 @@
+// Patrol E2E tests for the Supplies (pharmacy) feature.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mona/data/model/administration_route.dart';
+import 'package:mona/data/model/generic_supply_item.dart';
+import 'package:mona/data/model/molecule.dart';
+import 'package:mona/main.dart' as app;
+import 'package:mona/ui/views/supplies/supply_item_card.dart';
+import 'package:patrol/patrol.dart';
+
+// Keys for interaction targets, mirroring the ValueKeys set on the production
+// widgets under lib/ui/.
+const _navTabSupplies = ValueKey('navTabSupplies');
+
+// New item (shared first page): name, type toggle, "Next".
+const _newItemName = ValueKey('newItemName');
+const _newItemNext = ValueKey('newItemNext');
+const _newItemTypeGeneric = ValueKey('newItemTypeGeneric');
+
+// New medication item specifics: amounts + "Add".
+const _newMedicationItemTotalAmount = ValueKey('newMedicationItemTotalAmount');
+const _newMedicationItemConcentration =
+    ValueKey('newMedicationItemConcentration');
+const _newMedicationItemAdd = ValueKey('newMedicationItemAdd');
+
+// New generic item specifics: amount + "Add".
+const _newGenericItemAmount = ValueKey('newGenericItemAmount');
+const _newGenericItemAdd = ValueKey('newGenericItemAdd');
+
+// Edit medication item.
+const _editItemName = ValueKey('editItemName');
+const _editItemSave = ValueKey('editItemSave');
+const _editItemDelete = ValueKey('editItemDelete');
+
+const _confirmDelete = ValueKey('confirmDeleteConfirmButton');
+
+// User-visible strings asserted by these tests (see lib/l10n/app_en.arb).
+const _emptyState = 'No supplies. Add an item to get started.';
+
+// Dropdown option labels: selected by their visible (localized) text. The
+// option lists come from shared enum dropdown builders used app-wide, so they
+// are not individually keyed; the dropdowns themselves are opened with a stable
+// typed finder ($(DropdownButtonFormField<Molecule>)).
+const _moleculeEstradiol = 'Estradiol';
+const _routeOral = 'Oral';
+const _genericTypeSyringe = 'Syringes';
+
+void main() {
+  patrolTest('shows empty state when there are no supplies', ($) async {
+    await _launchApp($);
+    await _openSupplies($);
+
+    await $(_emptyState).waitUntilVisible();
+    expect($(_emptyState), findsOneWidget);
+  });
+
+  patrolTest('creates a medication item', ($) async {
+    await _launchApp($);
+    await _openSupplies($);
+
+    await _createMedicationItem($, name: 'Estradiol Vial');
+
+    // provider.add() is fire-and-forget; wait for the grid to rebuild.
+    await $('Estradiol Vial').waitUntilVisible();
+    expect($('Estradiol Vial'), findsOneWidget);
+    expect($(_emptyState), findsNothing);
+  });
+
+  patrolTest('creates a consumable item', ($) async {
+    await _launchApp($);
+    await _openSupplies($);
+
+    await _createGenericItem($, name: 'Spare Syringes');
+
+    await $('Spare Syringes').waitUntilVisible();
+    expect($('Spare Syringes'), findsOneWidget);
+    expect($(_emptyState), findsNothing);
+  });
+
+  patrolTest('edits an item name', ($) async {
+    await _launchApp($);
+    await _openSupplies($);
+    await _createMedicationItem($, name: 'Old Name');
+
+    await $(SupplyItemCard).containing('Old Name').tap(); // -> EditItemPage
+    await $(_editItemName).enterText('New Name');
+    await $(_editItemSave).tap(); // pops back to the supplies grid
+
+    await $('New Name').waitUntilVisible();
+    expect($('New Name'), findsOneWidget);
+    expect($('Old Name'), findsNothing);
+  });
+
+  patrolTest('deletes an item with confirmation', ($) async {
+    await _launchApp($);
+    await _openSupplies($);
+    await _createMedicationItem($, name: 'To Delete');
+
+    await $(SupplyItemCard).containing('To Delete').tap(); // -> EditItemPage
+    await $(_editItemDelete).tap(); // form's Delete button -> confirm dialog
+    await $(_confirmDelete).tap(); // confirm in the dialog
+
+    await $(_emptyState).waitUntilVisible();
+    expect($('To Delete'), findsNothing);
+    expect($(_emptyState), findsOneWidget);
+  });
+}
+
+/// Launches the real app and waits for the home screen to be interactive.
+Future<void> _launchApp(PatrolIntegrationTester $) async {
+  app.main();
+  await $.pumpAndSettle();
+  // main() initialises asynchronously (timezone data, preferences) before
+  // runApp; poll until the home AppBar's settings button is on screen.
+  await $(Icons.settings).waitUntilVisible();
+}
+
+/// Switches from the Home tab to the Supplies tab via the bottom navigation bar.
+Future<void> _openSupplies(PatrolIntegrationTester $) async {
+  await $(_navTabSupplies).tap(); // keyed NavigationDestination
+}
+
+/// From the Supplies tab: FAB -> first page (name, medication type is the
+/// default) -> Next -> specifics (Estradiol + Oral avoids the conditional Ester
+/// field) -> Add. Returns to the supplies grid.
+Future<void> _createMedicationItem(
+  PatrolIntegrationTester $, {
+  required String name,
+}) async {
+  await $(Icons.add).tap(); // FAB: "Add an item" -> NewItemPage
+  await $(_newItemName).enterText(name);
+  await $(_newItemNext).tap(); // -> NewMedicationItemSpecificsPage
+
+  await $(DropdownButtonFormField<Molecule>).tap();
+  await $(_moleculeEstradiol).tap();
+  await $(DropdownButtonFormField<AdministrationRoute>).tap();
+  await $(_routeOral).tap();
+
+  await $(_newMedicationItemTotalAmount).enterText('10');
+  await $(_newMedicationItemConcentration).enterText('2');
+  await $(_newMedicationItemAdd).tap(); // pops back to the supplies grid
+}
+
+/// From the Supplies tab: FAB -> first page (name, switch type to consumable)
+/// -> Next -> specifics (type + amount) -> Add. Returns to the supplies grid.
+Future<void> _createGenericItem(
+  PatrolIntegrationTester $, {
+  required String name,
+}) async {
+  await $(Icons.add).tap(); // FAB: "Add an item" -> NewItemPage
+  await $(_newItemName).enterText(name);
+  await $(_newItemTypeGeneric).tap(); // switch from medication to consumable
+  await $(_newItemNext).tap(); // -> NewGenericItemSpecificsPage
+
+  await $(DropdownButtonFormField<GenericSupplyType>).tap();
+  await $(_genericTypeSyringe).tap();
+
+  await $(_newGenericItemAmount).enterText('5');
+  await $(_newGenericItemAdd).tap(); // pops back to the supplies grid
+}

--- a/integration_test/supplies_test.dart
+++ b/integration_test/supplies_test.dart
@@ -5,13 +5,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mona/data/model/administration_route.dart';
 import 'package:mona/data/model/generic_supply_item.dart';
 import 'package:mona/data/model/molecule.dart';
-import 'package:mona/main.dart' as app;
 import 'package:mona/ui/views/supplies/supply_item_card.dart';
 import 'package:patrol/patrol.dart';
 
+import 'support/helpers.dart';
+
 // Keys for interaction targets, mirroring the ValueKeys set on the production
 // widgets under lib/ui/.
-const _navTabSupplies = ValueKey('navTabSupplies');
 
 // New item (shared first page): name, type toggle, "Next".
 const _newItemName = ValueKey('newItemName');
@@ -33,8 +33,6 @@ const _editItemName = ValueKey('editItemName');
 const _editItemSave = ValueKey('editItemSave');
 const _editItemDelete = ValueKey('editItemDelete');
 
-const _confirmDelete = ValueKey('confirmDeleteConfirmButton');
-
 // User-visible strings asserted by these tests (see lib/l10n/app_en.arb).
 const _emptyState = 'No supplies. Add an item to get started.';
 
@@ -48,16 +46,16 @@ const _genericTypeSyringe = 'Syringes';
 
 void main() {
   patrolTest('shows empty state when there are no supplies', ($) async {
-    await _launchApp($);
-    await _openSupplies($);
+    await $.launchApp();
+    await $.openSupplies();
 
     await $(_emptyState).waitUntilVisible();
     expect($(_emptyState), findsOneWidget);
   });
 
   patrolTest('creates a medication item', ($) async {
-    await _launchApp($);
-    await _openSupplies($);
+    await $.launchApp();
+    await $.openSupplies();
 
     await _createMedicationItem($, name: 'Estradiol Vial');
 
@@ -68,8 +66,8 @@ void main() {
   });
 
   patrolTest('creates a consumable item', ($) async {
-    await _launchApp($);
-    await _openSupplies($);
+    await $.launchApp();
+    await $.openSupplies();
 
     await _createGenericItem($, name: 'Spare Syringes');
 
@@ -79,8 +77,8 @@ void main() {
   });
 
   patrolTest('edits an item name', ($) async {
-    await _launchApp($);
-    await _openSupplies($);
+    await $.launchApp();
+    await $.openSupplies();
     await _createMedicationItem($, name: 'Old Name');
 
     await $(SupplyItemCard).containing('Old Name').tap(); // -> EditItemPage
@@ -93,32 +91,18 @@ void main() {
   });
 
   patrolTest('deletes an item with confirmation', ($) async {
-    await _launchApp($);
-    await _openSupplies($);
+    await $.launchApp();
+    await $.openSupplies();
     await _createMedicationItem($, name: 'To Delete');
 
     await $(SupplyItemCard).containing('To Delete').tap(); // -> EditItemPage
     await $(_editItemDelete).tap(); // form's Delete button -> confirm dialog
-    await $(_confirmDelete).tap(); // confirm in the dialog
+    await $(confirmDeleteButton).tap(); // confirm in the dialog
 
     await $(_emptyState).waitUntilVisible();
     expect($('To Delete'), findsNothing);
     expect($(_emptyState), findsOneWidget);
   });
-}
-
-/// Launches the real app and waits for the home screen to be interactive.
-Future<void> _launchApp(PatrolIntegrationTester $) async {
-  app.main();
-  await $.pumpAndSettle();
-  // main() initialises asynchronously (timezone data, preferences) before
-  // runApp; poll until the home AppBar's settings button is on screen.
-  await $(Icons.settings).waitUntilVisible();
-}
-
-/// Switches from the Home tab to the Supplies tab via the bottom navigation bar.
-Future<void> _openSupplies(PatrolIntegrationTester $) async {
-  await $(_navTabSupplies).tap(); // keyed NavigationDestination
 }
 
 /// From the Supplies tab: FAB -> first page (name, medication type is the

--- a/integration_test/supplies_test.dart
+++ b/integration_test/supplies_test.dart
@@ -36,10 +36,7 @@ const _editItemDelete = ValueKey('editItemDelete');
 // User-visible strings asserted by these tests (see lib/l10n/app_en.arb).
 const _emptyState = 'No supplies. Add an item to get started.';
 
-// Dropdown option labels: selected by their visible (localized) text. The
-// option lists come from shared enum dropdown builders used app-wide, so they
-// are not individually keyed; the dropdowns themselves are opened with a stable
-// typed finder ($(DropdownButtonFormField<Molecule>)).
+// Dropdown options aren't keyed. They're selected by visible localized text.
 const _moleculeEstradiol = 'Estradiol';
 const _routeOral = 'Oral';
 const _genericTypeSyringe = 'Syringes';

--- a/integration_test/support/helpers.dart
+++ b/integration_test/support/helpers.dart
@@ -1,0 +1,41 @@
+// Shared helpers for the Patrol E2E suite: app launch and per-feature
+// navigation, reused across the *_test.dart files.
+
+import 'package:flutter/material.dart';
+import 'package:mona/main.dart' as app;
+import 'package:patrol/patrol.dart';
+
+/// Confirm button in the shared delete-confirmation dialog (see dialogs.dart).
+const confirmDeleteButton = ValueKey('confirmDeleteConfirmButton');
+
+// Keyed navigation entry points (see main_tabs.dart / settings_page.dart).
+const _settingsSchedulesTile = ValueKey('settingsSchedulesTile');
+const _navTabIntakes = ValueKey('navTabIntakes');
+const _navTabSupplies = ValueKey('navTabSupplies');
+
+extension MonaHarness on PatrolIntegrationTester {
+  /// Launches the real app and waits for the home screen to be interactive.
+  Future<void> launchApp() async {
+    app.main();
+    await pumpAndSettle();
+    // main() initialises asynchronously (timezone data, preferences) before
+    // runApp; poll until the home AppBar's settings button is on screen.
+    await this(Icons.settings).waitUntilVisible();
+  }
+
+  /// Home -> Settings -> Schedules.
+  Future<void> openSchedules() async {
+    await this(Icons.settings).tap();
+    await this(_settingsSchedulesTile).scrollTo().tap();
+  }
+
+  /// Switches to the Intakes tab via the bottom navigation bar.
+  Future<void> openIntakes() async {
+    await this(_navTabIntakes).tap(); // keyed NavigationDestination
+  }
+
+  /// Switches to the Supplies tab via the bottom navigation bar.
+  Future<void> openSupplies() async {
+    await this(_navTabSupplies).tap(); // keyed NavigationDestination
+  }
+}

--- a/integration_test/support/helpers.dart
+++ b/integration_test/support/helpers.dart
@@ -13,7 +13,7 @@ const _settingsSchedulesTile = ValueKey('settingsSchedulesTile');
 const _navTabIntakes = ValueKey('navTabIntakes');
 const _navTabSupplies = ValueKey('navTabSupplies');
 
-extension MonaHarness on PatrolIntegrationTester {
+extension MonaHelper on PatrolIntegrationTester {
   /// Launches the real app and waits for the home screen to be interactive.
   Future<void> launchApp() async {
     app.main();

--- a/lib/ui/views/main_tabs.dart
+++ b/lib/ui/views/main_tabs.dart
@@ -70,6 +70,7 @@ List<MainTabConfig> getMainTabs(BuildContext context) {
       page: const PharmacyPage(),
       icon: Icons.medication_outlined,
       selectedIcon: Icons.medication,
+      navKey: const ValueKey('navTabSupplies'),
       buildFab: (context) => FloatingActionButton(
         tooltip: context.l10n.addAnItem,
         onPressed: () {

--- a/lib/ui/views/supplies/edit_generic_item_page.dart
+++ b/lib/ui/views/supplies/edit_generic_item_page.dart
@@ -94,6 +94,8 @@ class _EditItemPageState extends State<EditItemPage> {
       title: localizations.editItem,
       avatar: _genericSupplyType.icon,
       submitButtonLabel: localizations.save,
+      submitButtonKey: const ValueKey('editGenericItemSave'),
+      deleteButtonKey: const ValueKey('editGenericItemDelete'),
       isFormValid: _isFormValid,
       saveChanges: _saveChanges,
       onDelete: _confirmDelete,
@@ -101,6 +103,7 @@ class _EditItemPageState extends State<EditItemPage> {
         FormTextField(
           controller: _nameController,
           label: localizations.name,
+          fieldKey: const ValueKey('editGenericItemName'),
           onChanged: _refresh,
           inputType: TextInputType.text,
           errorText: _nameError,

--- a/lib/ui/views/supplies/edit_item_page.dart
+++ b/lib/ui/views/supplies/edit_item_page.dart
@@ -189,6 +189,8 @@ class _EditItemPageState extends State<EditItemPage> {
       title: localizations.editItem,
       avatar: _administrationRoute.icon,
       submitButtonLabel: localizations.save,
+      submitButtonKey: const ValueKey('editItemSave'),
+      deleteButtonKey: const ValueKey('editItemDelete'),
       isFormValid: _isFormValid,
       saveChanges: _saveChanges,
       onDelete: _confirmDelete,
@@ -196,6 +198,7 @@ class _EditItemPageState extends State<EditItemPage> {
         FormTextField(
           controller: _nameController,
           label: localizations.name,
+          fieldKey: const ValueKey('editItemName'),
           onChanged: _refresh,
           inputType: TextInputType.text,
           errorText: _nameError,

--- a/lib/ui/views/supplies/new_generic_item_specifics_page.dart
+++ b/lib/ui/views/supplies/new_generic_item_specifics_page.dart
@@ -76,6 +76,7 @@ class _NewGenericItemSpecificsPageState
       title: widget.name,
       avatar: _genericSupplyType?.icon ?? Symbols.medication,
       submitButtonLabel: localizations.add,
+      submitButtonKey: const ValueKey('newGenericItemAdd'),
       isFormValid: _isFormValid,
       saveChanges: _addItem,
       closeAll: _closeAll,
@@ -89,6 +90,7 @@ class _NewGenericItemSpecificsPageState
         FormTextField(
           controller: _amountController,
           label: localizations.amount,
+          fieldKey: const ValueKey('newGenericItemAmount'),
           onChanged: _refresh,
           inputType: TextInputType.number,
           regexFormatter: RegexPatterns.intNumber,

--- a/lib/ui/views/supplies/new_item_page.dart
+++ b/lib/ui/views/supplies/new_item_page.dart
@@ -61,12 +61,14 @@ class _NewItemPageState extends State<NewItemPage> {
       title: localizations.newItem,
       avatar: Symbols.medication,
       submitButtonLabel: localizations.next,
+      submitButtonKey: const ValueKey('newItemNext'),
       isFormValid: _isFormValid,
       saveChanges: _next,
       fields: [
         FormTextField(
           controller: _nameController,
           label: localizations.name,
+          fieldKey: const ValueKey('newItemName'),
           onChanged: _refresh,
           inputType: TextInputType.text,
         ),
@@ -95,9 +97,11 @@ class _NewItemPageState extends State<NewItemPage> {
         },
         actions: [
           M3EToggleButtonGroupAction(
-              label: Text(localizations.medicationItemType)),
+              label: Text(localizations.medicationItemType,
+                  key: const ValueKey('newItemTypeMedication'))),
           M3EToggleButtonGroupAction(
-              label: Text(localizations.genericItemType)),
+              label: Text(localizations.genericItemType,
+                  key: const ValueKey('newItemTypeGeneric'))),
         ],
       ),
     );

--- a/lib/ui/views/supplies/new_medication_item_specifics_page.dart
+++ b/lib/ui/views/supplies/new_medication_item_specifics_page.dart
@@ -149,6 +149,7 @@ class _NewMedicationItemSpecificsPageState
       title: widget.name,
       avatar: _administrationRoute?.icon ?? Symbols.medication,
       submitButtonLabel: localizations.add,
+      submitButtonKey: const ValueKey('newMedicationItemAdd'),
       isFormValid: _isFormValid,
       saveChanges: _addItem,
       closeAll: _closeAll,
@@ -179,6 +180,7 @@ class _NewMedicationItemSpecificsPageState
         FormTextField(
           controller: _totalAmountController,
           label: localizations.totalAmount,
+          fieldKey: const ValueKey('newMedicationItemTotalAmount'),
           onChanged: _refresh,
           inputType: TextInputType.numberWithOptions(decimal: true),
           suffixText: _administrationRoute?.localizedUnit(localizations, 1),
@@ -187,6 +189,7 @@ class _NewMedicationItemSpecificsPageState
         FormTextField(
           controller: _concentrationController,
           label: localizations.concentration,
+          fieldKey: const ValueKey('newMedicationItemConcentration'),
           onChanged: _refresh,
           inputType: TextInputType.numberWithOptions(decimal: true),
           suffixText: _molecule != null && _administrationRoute != null


### PR DESCRIPTION
### Description
Adds end-to-end (Patrol) test coverage for the Supplies/pharmacy feature.

**Tests** : empty state, create a medication item, create a consumable item, edit an item name, and delete an item with confirmation.

**Shared helpers refactor** : extracted duplicated code into a `helpers.dart` class and updated the existing test files to use it.
This file is intentionally not a `*_test.dart` file, so CI's per-file matrix skips it.

Related to issue(s): #229 

### Type of change
- New feature (non-breaking change which adds functionality)
- Maintenance