### PR TITLE
chore: disable slang_build_runner

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,5 @@
+targets:
+  $default:
+    builders:
+      slang_build_runner:
+        enabled: false


### PR DESCRIPTION
slang_build_runner ran on every `build_runner build` and emitted a second, stale copy of the i18n Dart code (lib/i18n/generated/strings*.g.dart) next to the JSON inputs. those files are gitignored but caused 9 persistent analyzer errors after any codegen run. i18n is generated by the standalone `dart run slang` CLI (scripts/i18n.sh) into lib/i18n/translations*.g.dart, which is the only output the app imports.