### PR TITLE
fix: preserve tab state and fix AppBar scrolled-under tint

### DIFF
--- a/lib/ui/views/main_page.dart
+++ b/lib/ui/views/main_page.dart
@@ -62,12 +62,18 @@ class _MainPageState extends State<MainPage> {
       },
       child: Scaffold(
         appBar: AppBar(
+          key: ValueKey(_selectedIndex),
           title: Text(currentTab.title),
           centerTitle: true,
           actions: currentTab.buildActions?.call(context),
         ),
         body: SafeArea(
-          child: currentTab.page,
+          child: IndexedStack(
+            index: _selectedIndex,
+            children: [
+              for (final tab in tabs) tab.page,
+            ],
+          ),
         ),
         bottomNavigationBar: Column(
           mainAxisSize: MainAxisSize.min,

--- a/lib/ui/views/main_page.dart
+++ b/lib/ui/views/main_page.dart
@@ -61,19 +61,19 @@ class _MainPageState extends State<MainPage> {
         }
       },
       child: Scaffold(
-        appBar: AppBar(
-          key: ValueKey(_selectedIndex),
-          title: Text(currentTab.title),
-          centerTitle: true,
-          actions: currentTab.buildActions?.call(context),
-        ),
-        body: SafeArea(
-          child: IndexedStack(
-            index: _selectedIndex,
-            children: [
-              for (final tab in tabs) tab.page,
-            ],
-          ),
+        body: IndexedStack(
+          index: _selectedIndex,
+          children: [
+            for (final tab in tabs)
+              Scaffold(
+                appBar: AppBar(
+                  title: Text(tab.title),
+                  centerTitle: true,
+                  actions: tab.buildActions?.call(context),
+                ),
+                body: SafeArea(child: tab.page),
+              ),
+          ],
         ),
         bottomNavigationBar: Column(
           mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
fixes #262 

corrects this bug, scrolling on intakes list then switching to levels :

<img width="458" height="338" alt="Screenshot 2026-07-09 at 10 28 50" src="https://github.com/user-attachments/assets/526add1b-24cb-4a28-bc7e-b73a1f6cdd41" />

now each page has its own scaffold that keeps the scroll position.