### PR TITLE
android home screen widgets (hrt progress, next dose, recent injections, status, supplies)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -85,6 +85,30 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/recent_intakes_widget_info"/>
         </receiver>
+        <!-- "Status" home screen widget, see StatusWidgetProvider.kt -->
+        <receiver
+            android:name=".StatusWidgetProvider"
+            android:exported="false"
+            android:label="@string/status_widget_label">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/status_widget_info"/>
+        </receiver>
+        <!-- "Supplies" home screen widget, see SuppliesWidgetProvider.kt -->
+        <receiver
+            android:name=".SuppliesWidgetProvider"
+            android:exported="false"
+            android:label="@string/supplies_widget_label">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/supplies_widget_info"/>
+        </receiver>
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -49,6 +49,18 @@
                 <action android:name="com.htc.intent.action.QUICKBOOT_POWERON"/>
             </intent-filter>
         </receiver>
+        <!-- "On HRT for X" home screen widget, see HrtWidgetProvider.kt -->
+        <receiver
+            android:name=".HrtWidgetProvider"
+            android:exported="false"
+            android:label="@string/hrt_widget_label">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/hrt_widget_info"/>
+        </receiver>
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -61,6 +61,30 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/hrt_widget_info"/>
         </receiver>
+        <!-- "Next dose" home screen widget, see NextDoseWidgetProvider.kt -->
+        <receiver
+            android:name=".NextDoseWidgetProvider"
+            android:exported="false"
+            android:label="@string/next_dose_widget_label">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/next_dose_widget_info"/>
+        </receiver>
+        <!-- "Recent injections" home screen widget, see RecentIntakesWidgetProvider.kt -->
+        <receiver
+            android:name=".RecentIntakesWidgetProvider"
+            android:exported="false"
+            android:label="@string/recent_intakes_widget_label">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/recent_intakes_widget_info"/>
+        </receiver>
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/android/app/src/main/kotlin/com/deliacheminot/mona/HrtWidgetProvider.kt
+++ b/android/app/src/main/kotlin/com/deliacheminot/mona/HrtWidgetProvider.kt
@@ -47,6 +47,18 @@ class HrtWidgetProvider : HomeWidgetProvider() {
                 else context.getString(R.string.hrt_widget_default_subtitle)
             )
 
+            WidgetColors.applyCard(
+                context, widgetData, views,
+                cardViewId = R.id.hrt_widget_card,
+                titleViewId = R.id.hrt_widget_title,
+                subtitleViewId = R.id.hrt_widget_subtitle,
+            )
+            WidgetColors.applyIcon(
+                context, widgetData, views,
+                circleViewId = R.id.hrt_widget_icon_circle,
+                glyphViewId = R.id.hrt_widget_icon,
+            )
+
             appWidgetManager.updateAppWidget(widgetId, views)
         }
     }

--- a/android/app/src/main/kotlin/com/deliacheminot/mona/HrtWidgetProvider.kt
+++ b/android/app/src/main/kotlin/com/deliacheminot/mona/HrtWidgetProvider.kt
@@ -1,0 +1,53 @@
+package com.deliacheminot.mona
+
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import android.content.SharedPreferences
+import android.widget.RemoteViews
+import es.antonborri.home_widget.HomeWidgetProvider
+
+/**
+ * Renders the "On HRT for X" progress card as a home screen widget.
+ *
+ * Data is written by Flutter's [HrtWidgetService] via the home_widget plugin
+ * (see lib/services/hrt_widget_service.dart) and stored under the keys
+ * below. This provider is purely a renderer: all duration math and
+ * localization happens on the Dart side so strings only ever need to be
+ * updated in one place.
+ */
+class HrtWidgetProvider : HomeWidgetProvider() {
+
+    companion object {
+        private const val KEY_TITLE = "hrt_widget_title"
+        private const val KEY_SUBTITLE = "hrt_widget_subtitle"
+        private const val KEY_ENABLED = "hrt_widget_enabled"
+    }
+
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray,
+        widgetData: SharedPreferences
+    ) {
+        appWidgetIds.forEach { widgetId ->
+            val views = RemoteViews(context.packageName, R.layout.hrt_widget)
+
+            val enabled = widgetData.getBoolean(KEY_ENABLED, true)
+            val title = widgetData.getString(KEY_TITLE, null)
+            val subtitle = widgetData.getString(KEY_SUBTITLE, null)
+
+            views.setTextViewText(
+                R.id.hrt_widget_title,
+                if (enabled && title != null) title
+                else context.getString(R.string.hrt_widget_default_title)
+            )
+            views.setTextViewText(
+                R.id.hrt_widget_subtitle,
+                if (enabled && subtitle != null) subtitle
+                else context.getString(R.string.hrt_widget_default_subtitle)
+            )
+
+            appWidgetManager.updateAppWidget(widgetId, views)
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/deliacheminot/mona/NextDoseWidgetProvider.kt
+++ b/android/app/src/main/kotlin/com/deliacheminot/mona/NextDoseWidgetProvider.kt
@@ -44,16 +44,25 @@ class NextDoseWidgetProvider : HomeWidgetProvider() {
                 subtitle ?: context.getString(R.string.next_dose_widget_default_subtitle)
             )
 
+            // Base drawable resource swap: the only way to distinguish overdue
+            // pre-API 31, where WidgetColors can't retint a shape at runtime.
             val circleDrawable =
                 if (overdue) R.drawable.widget_icon_circle_overdue
                 else R.drawable.hrt_widget_icon_circle
             views.setInt(R.id.next_dose_widget_icon_circle, "setBackgroundResource", circleDrawable)
 
-            val iconColor = context.getColor(
-                if (overdue) R.color.widget_overdue_icon_foreground
-                else R.color.hrt_widget_icon_foreground
+            WidgetColors.applyCard(
+                context, widgetData, views,
+                cardViewId = R.id.next_dose_widget_card,
+                titleViewId = R.id.next_dose_widget_title,
+                subtitleViewId = R.id.next_dose_widget_subtitle,
             )
-            views.setInt(R.id.next_dose_widget_icon, "setColorFilter", iconColor)
+            WidgetColors.applyIcon(
+                context, widgetData, views,
+                circleViewId = R.id.next_dose_widget_icon_circle,
+                glyphViewId = R.id.next_dose_widget_icon,
+                overdue = overdue,
+            )
 
             appWidgetManager.updateAppWidget(widgetId, views)
         }

--- a/android/app/src/main/kotlin/com/deliacheminot/mona/NextDoseWidgetProvider.kt
+++ b/android/app/src/main/kotlin/com/deliacheminot/mona/NextDoseWidgetProvider.kt
@@ -1,0 +1,61 @@
+package com.deliacheminot.mona
+
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import android.content.SharedPreferences
+import android.widget.RemoteViews
+import es.antonborri.home_widget.HomeWidgetProvider
+
+/**
+ * Renders the "next dose due" card as a home screen widget.
+ *
+ * Data is written by Flutter's [NextDoseWidgetService] via the home_widget
+ * plugin (see lib/services/next_dose_widget_service.dart) and stored under
+ * the keys below. This provider is purely a renderer: picking the most
+ * urgent schedule and all its localization happens on the Dart side.
+ */
+class NextDoseWidgetProvider : HomeWidgetProvider() {
+
+    companion object {
+        private const val KEY_TITLE = "next_dose_widget_title"
+        private const val KEY_SUBTITLE = "next_dose_widget_subtitle"
+        private const val KEY_OVERDUE = "next_dose_widget_overdue"
+    }
+
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray,
+        widgetData: SharedPreferences
+    ) {
+        appWidgetIds.forEach { widgetId ->
+            val views = RemoteViews(context.packageName, R.layout.next_dose_widget)
+
+            val title = widgetData.getString(KEY_TITLE, null)
+            val subtitle = widgetData.getString(KEY_SUBTITLE, null)
+            val overdue = widgetData.getBoolean(KEY_OVERDUE, false)
+
+            views.setTextViewText(
+                R.id.next_dose_widget_title,
+                title ?: context.getString(R.string.next_dose_widget_default_title)
+            )
+            views.setTextViewText(
+                R.id.next_dose_widget_subtitle,
+                subtitle ?: context.getString(R.string.next_dose_widget_default_subtitle)
+            )
+
+            val circleDrawable =
+                if (overdue) R.drawable.widget_icon_circle_overdue
+                else R.drawable.hrt_widget_icon_circle
+            views.setInt(R.id.next_dose_widget_icon_circle, "setBackgroundResource", circleDrawable)
+
+            val iconColor = context.getColor(
+                if (overdue) R.color.widget_overdue_icon_foreground
+                else R.color.hrt_widget_icon_foreground
+            )
+            views.setInt(R.id.next_dose_widget_icon, "setColorFilter", iconColor)
+
+            appWidgetManager.updateAppWidget(widgetId, views)
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/deliacheminot/mona/RecentIntakesWidgetProvider.kt
+++ b/android/app/src/main/kotlin/com/deliacheminot/mona/RecentIntakesWidgetProvider.kt
@@ -1,0 +1,84 @@
+package com.deliacheminot.mona
+
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import android.content.SharedPreferences
+import android.view.View
+import android.widget.RemoteViews
+import es.antonborri.home_widget.HomeWidgetProvider
+
+/**
+ * Renders the most recently logged intakes as a home screen widget.
+ *
+ * Data is written by Flutter's [RecentIntakesWidgetService] via the
+ * home_widget plugin (see lib/services/recent_intakes_widget_service.dart)
+ * and stored under the keys below. This provider is purely a renderer: date
+ * formatting and the "dose • molecule • route" summary are pre-rendered on
+ * the Dart side, same split as [HrtWidgetProvider] and [NextDoseWidgetProvider].
+ *
+ * The widget shows a fixed number of rows (no native scrolling/ListView),
+ * so it only ever displays up to [ROW_COUNT] intakes, hiding unused rows.
+ */
+class RecentIntakesWidgetProvider : HomeWidgetProvider() {
+
+    companion object {
+        private const val KEY_COUNT = "recent_intakes_widget_count"
+        private const val ROW_COUNT = 4
+
+        private val ROW_IDS = intArrayOf(
+            R.id.recent_intakes_widget_row_0,
+            R.id.recent_intakes_widget_row_1,
+            R.id.recent_intakes_widget_row_2,
+            R.id.recent_intakes_widget_row_3,
+        )
+        private val DATE_IDS = intArrayOf(
+            R.id.recent_intakes_widget_date_0,
+            R.id.recent_intakes_widget_date_1,
+            R.id.recent_intakes_widget_date_2,
+            R.id.recent_intakes_widget_date_3,
+        )
+        private val SUMMARY_IDS = intArrayOf(
+            R.id.recent_intakes_widget_summary_0,
+            R.id.recent_intakes_widget_summary_1,
+            R.id.recent_intakes_widget_summary_2,
+            R.id.recent_intakes_widget_summary_3,
+        )
+
+        private fun dateKey(index: Int) = "recent_intakes_widget_date_$index"
+        private fun summaryKey(index: Int) = "recent_intakes_widget_summary_$index"
+    }
+
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray,
+        widgetData: SharedPreferences
+    ) {
+        appWidgetIds.forEach { widgetId ->
+            val views = RemoteViews(context.packageName, R.layout.recent_intakes_widget)
+
+            val count = widgetData.getInt(KEY_COUNT, 0).coerceIn(0, ROW_COUNT)
+
+            views.setViewVisibility(
+                R.id.recent_intakes_widget_empty,
+                if (count == 0) View.VISIBLE else View.GONE
+            )
+            views.setViewVisibility(
+                R.id.recent_intakes_widget_rows,
+                if (count == 0) View.GONE else View.VISIBLE
+            )
+
+            for (i in 0 until ROW_COUNT) {
+                if (i >= count) {
+                    views.setViewVisibility(ROW_IDS[i], View.GONE)
+                    continue
+                }
+                views.setViewVisibility(ROW_IDS[i], View.VISIBLE)
+                views.setTextViewText(DATE_IDS[i], widgetData.getString(dateKey(i), null))
+                views.setTextViewText(SUMMARY_IDS[i], widgetData.getString(summaryKey(i), null))
+            }
+
+            appWidgetManager.updateAppWidget(widgetId, views)
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/deliacheminot/mona/RecentIntakesWidgetProvider.kt
+++ b/android/app/src/main/kotlin/com/deliacheminot/mona/RecentIntakesWidgetProvider.kt
@@ -43,6 +43,12 @@ class RecentIntakesWidgetProvider : HomeWidgetProvider() {
             R.id.recent_intakes_widget_summary_2,
             R.id.recent_intakes_widget_summary_3,
         )
+        private val ICON_IDS = intArrayOf(
+            R.id.recent_intakes_widget_icon_0,
+            R.id.recent_intakes_widget_icon_1,
+            R.id.recent_intakes_widget_icon_2,
+            R.id.recent_intakes_widget_icon_3,
+        )
 
         private fun dateKey(index: Int) = "recent_intakes_widget_date_$index"
         private fun summaryKey(index: Int) = "recent_intakes_widget_summary_$index"
@@ -68,6 +74,20 @@ class RecentIntakesWidgetProvider : HomeWidgetProvider() {
                 if (count == 0) View.GONE else View.VISIBLE
             )
 
+            WidgetColors.applyCard(
+                context, widgetData, views,
+                cardViewId = R.id.recent_intakes_widget_card,
+                titleViewId = R.id.recent_intakes_widget_header,
+            )
+            WidgetColors.applyText(
+                context, widgetData, views,
+                viewId = R.id.recent_intakes_widget_empty,
+                subtle = true,
+            )
+
+            // Row check marks use the same muted color as subtitle text.
+            val subtleColor = WidgetColors.textColor(context, widgetData, subtle = true)
+
             for (i in 0 until ROW_COUNT) {
                 if (i >= count) {
                     views.setViewVisibility(ROW_IDS[i], View.GONE)
@@ -76,6 +96,9 @@ class RecentIntakesWidgetProvider : HomeWidgetProvider() {
                 views.setViewVisibility(ROW_IDS[i], View.VISIBLE)
                 views.setTextViewText(DATE_IDS[i], widgetData.getString(dateKey(i), null))
                 views.setTextViewText(SUMMARY_IDS[i], widgetData.getString(summaryKey(i), null))
+                WidgetColors.applyText(context, widgetData, views, DATE_IDS[i])
+                WidgetColors.applyText(context, widgetData, views, SUMMARY_IDS[i], subtle = true)
+                views.setInt(ICON_IDS[i], "setColorFilter", subtleColor)
             }
 
             appWidgetManager.updateAppWidget(widgetId, views)

--- a/android/app/src/main/kotlin/com/deliacheminot/mona/StatusWidgetProvider.kt
+++ b/android/app/src/main/kotlin/com/deliacheminot/mona/StatusWidgetProvider.kt
@@ -1,0 +1,79 @@
+package com.deliacheminot.mona
+
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import android.content.SharedPreferences
+import android.widget.RemoteViews
+import es.antonborri.home_widget.HomeWidgetProvider
+
+/**
+ * Renders a compact square dashboard -- HRT duration, next dose, and the
+ * most urgent supply -- as a home screen widget.
+ *
+ * Data is written by Flutter's [StatusWidgetService] via the home_widget
+ * plugin (see lib/services/status_widget_service.dart) and stored under the
+ * keys below. This provider is purely a renderer: picking the next dose and
+ * the worst-off supply, and all localization, happens on the Dart side.
+ */
+class StatusWidgetProvider : HomeWidgetProvider() {
+
+    companion object {
+        private const val KEY_DURATION = "status_widget_duration"
+        private const val KEY_NEXT_DOSE = "status_widget_next_dose"
+        private const val KEY_NEXT_DOSE_OVERDUE = "status_widget_next_dose_overdue"
+        private const val KEY_SUPPLY = "status_widget_supply"
+        private const val KEY_SUPPLY_LOW = "status_widget_supply_low"
+    }
+
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray,
+        widgetData: SharedPreferences
+    ) {
+        appWidgetIds.forEach { widgetId ->
+            val views = RemoteViews(context.packageName, R.layout.status_widget)
+
+            val duration = widgetData.getString(KEY_DURATION, null)
+            val nextDose = widgetData.getString(KEY_NEXT_DOSE, null)
+            val nextDoseOverdue = widgetData.getBoolean(KEY_NEXT_DOSE_OVERDUE, false)
+            val supply = widgetData.getString(KEY_SUPPLY, null)
+            val supplyLow = widgetData.getBoolean(KEY_SUPPLY_LOW, false)
+
+            views.setTextViewText(
+                R.id.status_widget_duration_text,
+                duration ?: context.getString(R.string.status_widget_default_duration)
+            )
+            views.setTextViewText(
+                R.id.status_widget_next_dose_text,
+                nextDose ?: context.getString(R.string.status_widget_default_next_dose)
+            )
+            views.setTextViewText(
+                R.id.status_widget_supply_text,
+                supply ?: context.getString(R.string.status_widget_default_supply)
+            )
+
+            WidgetColors.applyCard(
+                context, widgetData, views,
+                cardViewId = R.id.status_widget_card,
+                titleViewId = R.id.status_widget_duration_text,
+            )
+            WidgetColors.applyText(context, widgetData, views, R.id.status_widget_next_dose_text)
+            WidgetColors.applyText(context, widgetData, views, R.id.status_widget_supply_text)
+
+            WidgetColors.applyIconTint(
+                context, widgetData, views, R.id.status_widget_duration_icon,
+            )
+            WidgetColors.applyIconTint(
+                context, widgetData, views, R.id.status_widget_next_dose_icon,
+                warning = nextDoseOverdue,
+            )
+            WidgetColors.applyIconTint(
+                context, widgetData, views, R.id.status_widget_supply_icon,
+                warning = supplyLow,
+            )
+
+            appWidgetManager.updateAppWidget(widgetId, views)
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/deliacheminot/mona/SuppliesWidgetProvider.kt
+++ b/android/app/src/main/kotlin/com/deliacheminot/mona/SuppliesWidgetProvider.kt
@@ -1,0 +1,107 @@
+package com.deliacheminot.mona
+
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import android.content.SharedPreferences
+import android.view.View
+import android.widget.RemoteViews
+import es.antonborri.home_widget.HomeWidgetProvider
+
+/**
+ * Renders the supply items running lowest as a home screen widget.
+ *
+ * Data is written by Flutter's [SuppliesWidgetService] via the home_widget
+ * plugin (see lib/services/supplies_widget_service.dart) and stored under
+ * the keys below. This provider is purely a renderer, same split as
+ * [RecentIntakesWidgetProvider].
+ *
+ * The widget shows a fixed number of rows (no native scrolling/ListView),
+ * so it only ever displays up to [ROW_COUNT] supplies, hiding unused rows.
+ * Rows for a critically low item get a warning-colored icon.
+ */
+class SuppliesWidgetProvider : HomeWidgetProvider() {
+
+    companion object {
+        private const val KEY_COUNT = "supplies_widget_count"
+        private const val ROW_COUNT = 4
+
+        private val ROW_IDS = intArrayOf(
+            R.id.supplies_widget_row_0,
+            R.id.supplies_widget_row_1,
+            R.id.supplies_widget_row_2,
+            R.id.supplies_widget_row_3,
+        )
+        private val NAME_IDS = intArrayOf(
+            R.id.supplies_widget_name_0,
+            R.id.supplies_widget_name_1,
+            R.id.supplies_widget_name_2,
+            R.id.supplies_widget_name_3,
+        )
+        private val SUMMARY_IDS = intArrayOf(
+            R.id.supplies_widget_summary_0,
+            R.id.supplies_widget_summary_1,
+            R.id.supplies_widget_summary_2,
+            R.id.supplies_widget_summary_3,
+        )
+        private val ICON_IDS = intArrayOf(
+            R.id.supplies_widget_icon_0,
+            R.id.supplies_widget_icon_1,
+            R.id.supplies_widget_icon_2,
+            R.id.supplies_widget_icon_3,
+        )
+
+        private fun nameKey(index: Int) = "supplies_widget_name_$index"
+        private fun summaryKey(index: Int) = "supplies_widget_summary_$index"
+        private fun lowKey(index: Int) = "supplies_widget_low_$index"
+    }
+
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray,
+        widgetData: SharedPreferences
+    ) {
+        appWidgetIds.forEach { widgetId ->
+            val views = RemoteViews(context.packageName, R.layout.supplies_widget)
+
+            val count = widgetData.getInt(KEY_COUNT, 0).coerceIn(0, ROW_COUNT)
+
+            views.setViewVisibility(
+                R.id.supplies_widget_empty,
+                if (count == 0) View.VISIBLE else View.GONE
+            )
+            views.setViewVisibility(
+                R.id.supplies_widget_rows,
+                if (count == 0) View.GONE else View.VISIBLE
+            )
+
+            WidgetColors.applyCard(
+                context, widgetData, views,
+                cardViewId = R.id.supplies_widget_card,
+                titleViewId = R.id.supplies_widget_header,
+            )
+            WidgetColors.applyText(
+                context, widgetData, views,
+                viewId = R.id.supplies_widget_empty,
+                subtle = true,
+            )
+
+            for (i in 0 until ROW_COUNT) {
+                if (i >= count) {
+                    views.setViewVisibility(ROW_IDS[i], View.GONE)
+                    continue
+                }
+                val low = widgetData.getBoolean(lowKey(i), false)
+
+                views.setViewVisibility(ROW_IDS[i], View.VISIBLE)
+                views.setTextViewText(NAME_IDS[i], widgetData.getString(nameKey(i), null))
+                views.setTextViewText(SUMMARY_IDS[i], widgetData.getString(summaryKey(i), null))
+                WidgetColors.applyText(context, widgetData, views, NAME_IDS[i])
+                WidgetColors.applyText(context, widgetData, views, SUMMARY_IDS[i], subtle = true)
+                WidgetColors.applyIconTint(context, widgetData, views, ICON_IDS[i], warning = low)
+            }
+
+            appWidgetManager.updateAppWidget(widgetId, views)
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/deliacheminot/mona/WidgetColors.kt
+++ b/android/app/src/main/kotlin/com/deliacheminot/mona/WidgetColors.kt
@@ -108,6 +108,34 @@ object WidgetColors {
         )
     }
 
+    /** The resolved icon glyph color: normal, or the app's error color when [warning]. */
+    fun iconColor(
+        context: Context,
+        widgetData: SharedPreferences,
+        warning: Boolean = false,
+    ): Int {
+        val key = if (warning) "widget_overdue_icon_foreground" else "widget_icon_foreground"
+        val fallback =
+            if (warning) R.color.widget_overdue_icon_foreground else R.color.hrt_widget_icon_foreground
+        return color(context, widgetData, key, fallback)
+    }
+
+    /**
+     * Tints a plain (no circle background) icon glyph, e.g. a row marker,
+     * using the app's error color instead when [warning] -- same accent
+     * [applyIcon] uses for an overdue circle, just for icons with no
+     * background of their own.
+     */
+    fun applyIconTint(
+        context: Context,
+        widgetData: SharedPreferences,
+        views: RemoteViews,
+        viewId: Int,
+        warning: Boolean = false,
+    ) {
+        views.setInt(viewId, "setColorFilter", iconColor(context, widgetData, warning))
+    }
+
     /** Tints a plain (non-circle) text/icon color, e.g. an empty-state message. */
     fun applyText(
         context: Context,

--- a/android/app/src/main/kotlin/com/deliacheminot/mona/WidgetColors.kt
+++ b/android/app/src/main/kotlin/com/deliacheminot/mona/WidgetColors.kt
@@ -1,0 +1,132 @@
+package com.deliacheminot.mona
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.content.res.ColorStateList
+import android.content.res.Configuration
+import android.os.Build
+import android.widget.RemoteViews
+import androidx.core.content.ContextCompat
+
+/**
+ * Applies Mona's *actual current* Material color scheme to a widget's card
+ * background, icon, and text views, instead of a color baked into the APK.
+ *
+ * [WidgetThemeService] (lib/services/widget_theme_service.dart) resolves the
+ * app's live ColorScheme -- honoring Material You dynamic color, custom
+ * themes, and light/dark mode -- and pushes both light and dark variants via
+ * home_widget. This picks whichever matches the device's current night
+ * mode, falling back to colors.xml (Mona's default, non-dynamic light
+ * scheme) before the app has synced once.
+ *
+ * Retinting a shape drawable's fill color at runtime needs
+ * [RemoteViews.setColorStateList], added in API 31, so below that the
+ * widgets keep colors.xml's static look.
+ */
+object WidgetColors {
+    private fun isNightMode(context: Context): Boolean {
+        val mode = context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+        return mode == Configuration.UI_MODE_NIGHT_YES
+    }
+
+    private fun color(
+        context: Context,
+        widgetData: SharedPreferences,
+        key: String,
+        fallbackRes: Int,
+    ): Int {
+        val suffix = if (isNightMode(context)) "dark" else "light"
+        val fallback = ContextCompat.getColor(context, fallbackRes)
+        val fullKey = "${key}_$suffix"
+
+        // home_widget stores Dart `int`s as either a Kotlin Int or Long
+        // depending on the value's magnitude (Flutter's platform channel
+        // codec picks Int32 vs Int64). Every opaque ARGB color from
+        // Color.toARGB32() is > 2^31, so in practice these always land here
+        // as a Long -- but fall back to getInt for safety, e.g. a
+        // semi-transparent color small enough to have been sent as Int32.
+        return try {
+            widgetData.getLong(fullKey, fallback.toLong()).toInt()
+        } catch (e: ClassCastException) {
+            widgetData.getInt(fullKey, fallback)
+        }
+    }
+
+    private fun tintBackground(views: RemoteViews, viewId: Int, color: Int) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            views.setColorStateList(viewId, "setBackgroundTintList", ColorStateList.valueOf(color))
+        }
+    }
+
+    /** Tints [cardViewId]'s card background and the title/subtitle text colors. */
+    fun applyCard(
+        context: Context,
+        widgetData: SharedPreferences,
+        views: RemoteViews,
+        cardViewId: Int,
+        titleViewId: Int,
+        subtitleViewId: Int? = null,
+    ) {
+        tintBackground(
+            views, cardViewId,
+            color(context, widgetData, "widget_card_background", R.color.hrt_widget_card_background),
+        )
+        views.setTextColor(
+            titleViewId,
+            color(context, widgetData, "widget_title_text", R.color.hrt_widget_title_text),
+        )
+        if (subtitleViewId != null) {
+            views.setTextColor(
+                subtitleViewId,
+                color(context, widgetData, "widget_subtitle_text", R.color.hrt_widget_subtitle_text),
+            )
+        }
+    }
+
+    /** Tints an icon circle + its glyph, using the app's error colors instead when [overdue]. */
+    fun applyIcon(
+        context: Context,
+        widgetData: SharedPreferences,
+        views: RemoteViews,
+        circleViewId: Int,
+        glyphViewId: Int,
+        overdue: Boolean = false,
+    ) {
+        val backgroundKey =
+            if (overdue) "widget_overdue_icon_background" else "widget_icon_background"
+        val backgroundFallback =
+            if (overdue) R.color.widget_overdue_icon_background else R.color.hrt_widget_icon_background
+        val foregroundKey =
+            if (overdue) "widget_overdue_icon_foreground" else "widget_icon_foreground"
+        val foregroundFallback =
+            if (overdue) R.color.widget_overdue_icon_foreground else R.color.hrt_widget_icon_foreground
+
+        tintBackground(views, circleViewId, color(context, widgetData, backgroundKey, backgroundFallback))
+        views.setInt(
+            glyphViewId, "setColorFilter",
+            color(context, widgetData, foregroundKey, foregroundFallback),
+        )
+    }
+
+    /** Tints a plain (non-circle) text/icon color, e.g. an empty-state message. */
+    fun applyText(
+        context: Context,
+        widgetData: SharedPreferences,
+        views: RemoteViews,
+        viewId: Int,
+        subtle: Boolean = false,
+    ) {
+        views.setTextColor(viewId, textColor(context, widgetData, subtle))
+    }
+
+    /** The resolved subtitle (muted) or title (primary) text color, for ad-hoc use. */
+    fun textColor(
+        context: Context,
+        widgetData: SharedPreferences,
+        subtle: Boolean = false,
+    ): Int {
+        val key = if (subtle) "widget_subtitle_text" else "widget_title_text"
+        val fallback = if (subtle) R.color.hrt_widget_subtitle_text else R.color.hrt_widget_title_text
+        return color(context, widgetData, key, fallback)
+    }
+}

--- a/android/app/src/main/res/drawable/hrt_widget_background.xml
+++ b/android/app/src/main/res/drawable/hrt_widget_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/hrt_widget_card_background" />
+    <corners android:radius="24dp" />
+</shape>

--- a/android/app/src/main/res/drawable/hrt_widget_icon_circle.xml
+++ b/android/app/src/main/res/drawable/hrt_widget_icon_circle.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="@color/hrt_widget_icon_background" />
+</shape>

--- a/android/app/src/main/res/drawable/ic_hrt_widget_calendar.xml
+++ b/android/app/src/main/res/drawable/ic_hrt_widget_calendar.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/hrt_widget_icon_foreground">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M7,10h5v5H7z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19,3h-1V1h-2v2H8V1H6v2H5C3.89,3 3,3.9 3,5v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2L21,5C21,3.9 20.1,3 19,3zM19,19L5,19L5,8h14V19z" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_widget_check.xml
+++ b/android/app/src/main/res/drawable/ic_widget_check.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/hrt_widget_icon_foreground">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19 21,7l-1.41,-1.41z" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_widget_clock.xml
+++ b/android/app/src/main/res/drawable/ic_widget_clock.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/hrt_widget_icon_foreground">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12.5,7H11v6l5.25,3.15 0.75,-1.23 -4.5,-2.67z" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_widget_inventory.xml
+++ b/android/app/src/main/res/drawable/ic_widget_inventory.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/hrt_widget_icon_foreground">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M20,2L4,2C2.9,2 2,2.9 2,4v3.01c0,0.72 0.43,1.34 1,1.69V20c0,1.1 1.1,2 2,2h14c0.9,0 2,-0.9 2,-2V8.7c0.57,-0.35 1,-0.97 1,-1.69V4C22,2.9 21.1,2 20,2zM4,4h16v3H4V4zM5,20V9h14v11H5zM9,12h6v2H9z" />
+</vector>

--- a/android/app/src/main/res/drawable/widget_icon_circle_overdue.xml
+++ b/android/app/src/main/res/drawable/widget_icon_circle_overdue.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="@color/widget_overdue_icon_background" />
+</shape>

--- a/android/app/src/main/res/layout/hrt_widget.xml
+++ b/android/app/src/main/res/layout/hrt_widget.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:padding="16dp"
+    android:background="@drawable/hrt_widget_background">
+
+    <FrameLayout
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:background="@drawable/hrt_widget_icon_circle">
+
+        <ImageView
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_gravity="center"
+            android:src="@drawable/ic_hrt_widget_calendar"
+            android:contentDescription="@null" />
+    </FrameLayout>
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:layout_marginStart="16dp"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/hrt_widget_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="@color/hrt_widget_title_text"
+            android:textSize="17sp"
+            android:textStyle="bold"
+            android:maxLines="1"
+            android:ellipsize="end"
+            android:text="@string/hrt_widget_default_title" />
+
+        <TextView
+            android:id="@+id/hrt_widget_subtitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:textColor="@color/hrt_widget_subtitle_text"
+            android:textSize="13sp"
+            android:maxLines="1"
+            android:ellipsize="end"
+            android:text="@string/hrt_widget_default_subtitle" />
+    </LinearLayout>
+</LinearLayout>

--- a/android/app/src/main/res/layout/hrt_widget.xml
+++ b/android/app/src/main/res/layout/hrt_widget.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/hrt_widget_card"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:padding="16dp"
@@ -12,12 +13,14 @@
         android:gravity="center_vertical">
 
         <FrameLayout
+            android:id="@+id/hrt_widget_icon_circle"
             android:layout_width="48dp"
             android:layout_height="48dp"
             android:layout_gravity="center_vertical"
             android:background="@drawable/hrt_widget_icon_circle">
 
             <ImageView
+                android:id="@+id/hrt_widget_icon"
                 android:layout_width="24dp"
                 android:layout_height="24dp"
                 android:layout_gravity="center"

--- a/android/app/src/main/res/layout/hrt_widget.xml
+++ b/android/app/src/main/res/layout/hrt_widget.xml
@@ -1,52 +1,57 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="horizontal"
-    android:gravity="center_vertical"
     android:padding="16dp"
     android:background="@drawable/hrt_widget_background">
 
-    <FrameLayout
-        android:layout_width="48dp"
-        android:layout_height="48dp"
-        android:background="@drawable/hrt_widget_icon_circle">
-
-        <ImageView
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:layout_gravity="center"
-            android:src="@drawable/ic_hrt_widget_calendar"
-            android:contentDescription="@null" />
-    </FrameLayout>
-
     <LinearLayout
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:layout_marginStart="16dp"
-        android:orientation="vertical">
+        android:layout_gravity="center"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
 
-        <TextView
-            android:id="@+id/hrt_widget_title"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:textColor="@color/hrt_widget_title_text"
-            android:textSize="17sp"
-            android:textStyle="bold"
-            android:maxLines="1"
-            android:ellipsize="end"
-            android:text="@string/hrt_widget_default_title" />
+        <FrameLayout
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:background="@drawable/hrt_widget_icon_circle">
 
-        <TextView
-            android:id="@+id/hrt_widget_subtitle"
-            android:layout_width="match_parent"
+            <ImageView
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_gravity="center"
+                android:src="@drawable/ic_hrt_widget_calendar"
+                android:contentDescription="@null" />
+        </FrameLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="2dp"
-            android:textColor="@color/hrt_widget_subtitle_text"
-            android:textSize="13sp"
-            android:maxLines="1"
-            android:ellipsize="end"
-            android:text="@string/hrt_widget_default_subtitle" />
+            android:layout_marginStart="16dp"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/hrt_widget_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/hrt_widget_title_text"
+                android:textSize="17sp"
+                android:textStyle="bold"
+                android:maxLines="1"
+                android:ellipsize="end"
+                android:text="@string/hrt_widget_default_title" />
+
+            <TextView
+                android:id="@+id/hrt_widget_subtitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:textColor="@color/hrt_widget_subtitle_text"
+                android:textSize="13sp"
+                android:maxLines="1"
+                android:ellipsize="end"
+                android:text="@string/hrt_widget_default_subtitle" />
+        </LinearLayout>
     </LinearLayout>
-</LinearLayout>
+</FrameLayout>

--- a/android/app/src/main/res/layout/hrt_widget.xml
+++ b/android/app/src/main/res/layout/hrt_widget.xml
@@ -6,15 +6,15 @@
     android:background="@drawable/hrt_widget_background">
 
     <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:orientation="horizontal"
         android:gravity="center_vertical">
 
         <FrameLayout
             android:layout_width="48dp"
             android:layout_height="48dp"
+            android:layout_gravity="center_vertical"
             android:background="@drawable/hrt_widget_icon_circle">
 
             <ImageView
@@ -25,32 +25,48 @@
                 android:contentDescription="@null" />
         </FrameLayout>
 
+        <!--
+          Width AND height are bounded (0dp+weight, match_parent) rather than
+          wrap_content so the auto-size TextViews below have real room to grow
+          into as the widget is resized larger in either direction, not just
+          whatever their text naturally measures at.
+        -->
         <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
             android:layout_marginStart="16dp"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            android:gravity="center_vertical">
 
             <TextView
                 android:id="@+id/hrt_widget_title"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:textColor="@color/hrt_widget_title_text"
                 android:textSize="17sp"
                 android:textStyle="bold"
                 android:maxLines="1"
                 android:ellipsize="end"
+                android:autoSizeTextType="uniform"
+                android:autoSizeMinTextSize="12sp"
+                android:autoSizeMaxTextSize="32sp"
+                android:autoSizeStepGranularity="1sp"
                 android:text="@string/hrt_widget_default_title" />
 
             <TextView
                 android:id="@+id/hrt_widget_subtitle"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="2dp"
                 android:textColor="@color/hrt_widget_subtitle_text"
                 android:textSize="13sp"
                 android:maxLines="1"
                 android:ellipsize="end"
+                android:autoSizeTextType="uniform"
+                android:autoSizeMinTextSize="10sp"
+                android:autoSizeMaxTextSize="22sp"
+                android:autoSizeStepGranularity="1sp"
                 android:text="@string/hrt_widget_default_subtitle" />
         </LinearLayout>
     </LinearLayout>

--- a/android/app/src/main/res/layout/next_dose_widget.xml
+++ b/android/app/src/main/res/layout/next_dose_widget.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp"
+    android:background="@drawable/hrt_widget_background">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+
+        <FrameLayout
+            android:id="@+id/next_dose_widget_icon_circle"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_gravity="center_vertical"
+            android:background="@drawable/hrt_widget_icon_circle">
+
+            <ImageView
+                android:id="@+id/next_dose_widget_icon"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_gravity="center"
+                android:src="@drawable/ic_widget_clock"
+                android:contentDescription="@null" />
+        </FrameLayout>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:layout_marginStart="16dp"
+            android:orientation="vertical"
+            android:gravity="center_vertical">
+
+            <TextView
+                android:id="@+id/next_dose_widget_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textColor="@color/hrt_widget_title_text"
+                android:textSize="17sp"
+                android:textStyle="bold"
+                android:maxLines="1"
+                android:ellipsize="end"
+                android:autoSizeTextType="uniform"
+                android:autoSizeMinTextSize="12sp"
+                android:autoSizeMaxTextSize="32sp"
+                android:autoSizeStepGranularity="1sp"
+                android:text="@string/next_dose_widget_default_title" />
+
+            <TextView
+                android:id="@+id/next_dose_widget_subtitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:textColor="@color/hrt_widget_subtitle_text"
+                android:textSize="13sp"
+                android:maxLines="1"
+                android:ellipsize="end"
+                android:autoSizeTextType="uniform"
+                android:autoSizeMinTextSize="10sp"
+                android:autoSizeMaxTextSize="22sp"
+                android:autoSizeStepGranularity="1sp"
+                android:text="@string/next_dose_widget_default_subtitle" />
+        </LinearLayout>
+    </LinearLayout>
+</FrameLayout>

--- a/android/app/src/main/res/layout/next_dose_widget.xml
+++ b/android/app/src/main/res/layout/next_dose_widget.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/next_dose_widget_card"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:padding="16dp"

--- a/android/app/src/main/res/layout/recent_intakes_widget.xml
+++ b/android/app/src/main/res/layout/recent_intakes_widget.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/recent_intakes_widget_card"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:padding="16dp"
@@ -23,6 +24,7 @@
         android:orientation="vertical">
 
         <TextView
+            android:id="@+id/recent_intakes_widget_header"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginBottom="8dp"
@@ -40,6 +42,7 @@
             android:gravity="center_vertical">
 
             <ImageView
+                android:id="@+id/recent_intakes_widget_icon_0"
                 android:layout_width="16dp"
                 android:layout_height="16dp"
                 android:layout_marginEnd="8dp"
@@ -91,6 +94,7 @@
             android:gravity="center_vertical">
 
             <ImageView
+                android:id="@+id/recent_intakes_widget_icon_1"
                 android:layout_width="16dp"
                 android:layout_height="16dp"
                 android:layout_marginEnd="8dp"
@@ -142,6 +146,7 @@
             android:gravity="center_vertical">
 
             <ImageView
+                android:id="@+id/recent_intakes_widget_icon_2"
                 android:layout_width="16dp"
                 android:layout_height="16dp"
                 android:layout_marginEnd="8dp"
@@ -193,6 +198,7 @@
             android:gravity="center_vertical">
 
             <ImageView
+                android:id="@+id/recent_intakes_widget_icon_3"
                 android:layout_width="16dp"
                 android:layout_height="16dp"
                 android:layout_marginEnd="8dp"

--- a/android/app/src/main/res/layout/recent_intakes_widget.xml
+++ b/android/app/src/main/res/layout/recent_intakes_widget.xml
@@ -1,0 +1,238 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp"
+    android:background="@drawable/hrt_widget_background">
+
+    <TextView
+        android:id="@+id/recent_intakes_widget_empty"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_gravity="center"
+        android:gravity="center"
+        android:textColor="@color/hrt_widget_subtitle_text"
+        android:textSize="13sp"
+        android:visibility="gone"
+        android:text="@string/recent_intakes_widget_empty" />
+
+    <LinearLayout
+        android:id="@+id/recent_intakes_widget_rows"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:textColor="@color/hrt_widget_title_text"
+            android:textSize="15sp"
+            android:textStyle="bold"
+            android:text="@string/recent_intakes_widget_title" />
+
+        <LinearLayout
+            android:id="@+id/recent_intakes_widget_row_0"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <ImageView
+                android:layout_width="16dp"
+                android:layout_height="16dp"
+                android:layout_marginEnd="8dp"
+                android:src="@drawable/ic_widget_check"
+                android:contentDescription="@null" />
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:gravity="center_vertical">
+
+                <TextView
+                    android:id="@+id/recent_intakes_widget_date_0"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/hrt_widget_title_text"
+                    android:textStyle="bold"
+                    android:textSize="13sp"
+                    android:maxLines="1"
+                    android:ellipsize="end"
+                    android:autoSizeTextType="uniform"
+                    android:autoSizeMinTextSize="10sp"
+                    android:autoSizeMaxTextSize="18sp"
+                    android:autoSizeStepGranularity="1sp" />
+
+                <TextView
+                    android:id="@+id/recent_intakes_widget_summary_0"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/hrt_widget_subtitle_text"
+                    android:textSize="11sp"
+                    android:maxLines="1"
+                    android:ellipsize="end"
+                    android:autoSizeTextType="uniform"
+                    android:autoSizeMinTextSize="9sp"
+                    android:autoSizeMaxTextSize="15sp"
+                    android:autoSizeStepGranularity="1sp" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/recent_intakes_widget_row_1"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <ImageView
+                android:layout_width="16dp"
+                android:layout_height="16dp"
+                android:layout_marginEnd="8dp"
+                android:src="@drawable/ic_widget_check"
+                android:contentDescription="@null" />
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:gravity="center_vertical">
+
+                <TextView
+                    android:id="@+id/recent_intakes_widget_date_1"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/hrt_widget_title_text"
+                    android:textStyle="bold"
+                    android:textSize="13sp"
+                    android:maxLines="1"
+                    android:ellipsize="end"
+                    android:autoSizeTextType="uniform"
+                    android:autoSizeMinTextSize="10sp"
+                    android:autoSizeMaxTextSize="18sp"
+                    android:autoSizeStepGranularity="1sp" />
+
+                <TextView
+                    android:id="@+id/recent_intakes_widget_summary_1"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/hrt_widget_subtitle_text"
+                    android:textSize="11sp"
+                    android:maxLines="1"
+                    android:ellipsize="end"
+                    android:autoSizeTextType="uniform"
+                    android:autoSizeMinTextSize="9sp"
+                    android:autoSizeMaxTextSize="15sp"
+                    android:autoSizeStepGranularity="1sp" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/recent_intakes_widget_row_2"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <ImageView
+                android:layout_width="16dp"
+                android:layout_height="16dp"
+                android:layout_marginEnd="8dp"
+                android:src="@drawable/ic_widget_check"
+                android:contentDescription="@null" />
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:gravity="center_vertical">
+
+                <TextView
+                    android:id="@+id/recent_intakes_widget_date_2"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/hrt_widget_title_text"
+                    android:textStyle="bold"
+                    android:textSize="13sp"
+                    android:maxLines="1"
+                    android:ellipsize="end"
+                    android:autoSizeTextType="uniform"
+                    android:autoSizeMinTextSize="10sp"
+                    android:autoSizeMaxTextSize="18sp"
+                    android:autoSizeStepGranularity="1sp" />
+
+                <TextView
+                    android:id="@+id/recent_intakes_widget_summary_2"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/hrt_widget_subtitle_text"
+                    android:textSize="11sp"
+                    android:maxLines="1"
+                    android:ellipsize="end"
+                    android:autoSizeTextType="uniform"
+                    android:autoSizeMinTextSize="9sp"
+                    android:autoSizeMaxTextSize="15sp"
+                    android:autoSizeStepGranularity="1sp" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/recent_intakes_widget_row_3"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <ImageView
+                android:layout_width="16dp"
+                android:layout_height="16dp"
+                android:layout_marginEnd="8dp"
+                android:src="@drawable/ic_widget_check"
+                android:contentDescription="@null" />
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:gravity="center_vertical">
+
+                <TextView
+                    android:id="@+id/recent_intakes_widget_date_3"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/hrt_widget_title_text"
+                    android:textStyle="bold"
+                    android:textSize="13sp"
+                    android:maxLines="1"
+                    android:ellipsize="end"
+                    android:autoSizeTextType="uniform"
+                    android:autoSizeMinTextSize="10sp"
+                    android:autoSizeMaxTextSize="18sp"
+                    android:autoSizeStepGranularity="1sp" />
+
+                <TextView
+                    android:id="@+id/recent_intakes_widget_summary_3"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/hrt_widget_subtitle_text"
+                    android:textSize="11sp"
+                    android:maxLines="1"
+                    android:ellipsize="end"
+                    android:autoSizeTextType="uniform"
+                    android:autoSizeMinTextSize="9sp"
+                    android:autoSizeMaxTextSize="15sp"
+                    android:autoSizeStepGranularity="1sp" />
+            </LinearLayout>
+        </LinearLayout>
+    </LinearLayout>
+</FrameLayout>

--- a/android/app/src/main/res/layout/status_widget.xml
+++ b/android/app/src/main/res/layout/status_widget.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/status_widget_card"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp"
+    android:background="@drawable/hrt_widget_background">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <ImageView
+                android:id="@+id/status_widget_duration_icon"
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:layout_marginEnd="8dp"
+                android:src="@drawable/ic_hrt_widget_calendar"
+                android:contentDescription="@null" />
+
+            <TextView
+                android:id="@+id/status_widget_duration_text"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:gravity="center_vertical"
+                android:textColor="@color/hrt_widget_title_text"
+                android:textStyle="bold"
+                android:textSize="15sp"
+                android:maxLines="1"
+                android:ellipsize="end"
+                android:autoSizeTextType="uniform"
+                android:autoSizeMinTextSize="10sp"
+                android:autoSizeMaxTextSize="20sp"
+                android:autoSizeStepGranularity="1sp"
+                android:text="@string/status_widget_default_duration" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <ImageView
+                android:id="@+id/status_widget_next_dose_icon"
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:layout_marginEnd="8dp"
+                android:src="@drawable/ic_widget_clock"
+                android:contentDescription="@null" />
+
+            <TextView
+                android:id="@+id/status_widget_next_dose_text"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:gravity="center_vertical"
+                android:textColor="@color/hrt_widget_title_text"
+                android:textStyle="bold"
+                android:textSize="15sp"
+                android:maxLines="1"
+                android:ellipsize="end"
+                android:autoSizeTextType="uniform"
+                android:autoSizeMinTextSize="10sp"
+                android:autoSizeMaxTextSize="20sp"
+                android:autoSizeStepGranularity="1sp"
+                android:text="@string/status_widget_default_next_dose" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <ImageView
+                android:id="@+id/status_widget_supply_icon"
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:layout_marginEnd="8dp"
+                android:src="@drawable/ic_widget_inventory"
+                android:contentDescription="@null" />
+
+            <TextView
+                android:id="@+id/status_widget_supply_text"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:gravity="center_vertical"
+                android:textColor="@color/hrt_widget_title_text"
+                android:textStyle="bold"
+                android:textSize="15sp"
+                android:maxLines="1"
+                android:ellipsize="end"
+                android:autoSizeTextType="uniform"
+                android:autoSizeMinTextSize="10sp"
+                android:autoSizeMaxTextSize="20sp"
+                android:autoSizeStepGranularity="1sp"
+                android:text="@string/status_widget_default_supply" />
+        </LinearLayout>
+    </LinearLayout>
+</FrameLayout>

--- a/android/app/src/main/res/layout/supplies_widget.xml
+++ b/android/app/src/main/res/layout/supplies_widget.xml
@@ -1,0 +1,244 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/supplies_widget_card"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp"
+    android:background="@drawable/hrt_widget_background">
+
+    <TextView
+        android:id="@+id/supplies_widget_empty"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_gravity="center"
+        android:gravity="center"
+        android:textColor="@color/hrt_widget_subtitle_text"
+        android:textSize="13sp"
+        android:visibility="gone"
+        android:text="@string/supplies_widget_empty" />
+
+    <LinearLayout
+        android:id="@+id/supplies_widget_rows"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/supplies_widget_header"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:textColor="@color/hrt_widget_title_text"
+            android:textSize="15sp"
+            android:textStyle="bold"
+            android:text="@string/supplies_widget_title" />
+
+        <LinearLayout
+            android:id="@+id/supplies_widget_row_0"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <ImageView
+                android:id="@+id/supplies_widget_icon_0"
+                android:layout_width="16dp"
+                android:layout_height="16dp"
+                android:layout_marginEnd="8dp"
+                android:src="@drawable/ic_widget_inventory"
+                android:contentDescription="@null" />
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:gravity="center_vertical">
+
+                <TextView
+                    android:id="@+id/supplies_widget_name_0"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/hrt_widget_title_text"
+                    android:textStyle="bold"
+                    android:textSize="13sp"
+                    android:maxLines="1"
+                    android:ellipsize="end"
+                    android:autoSizeTextType="uniform"
+                    android:autoSizeMinTextSize="10sp"
+                    android:autoSizeMaxTextSize="18sp"
+                    android:autoSizeStepGranularity="1sp" />
+
+                <TextView
+                    android:id="@+id/supplies_widget_summary_0"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/hrt_widget_subtitle_text"
+                    android:textSize="11sp"
+                    android:maxLines="1"
+                    android:ellipsize="end"
+                    android:autoSizeTextType="uniform"
+                    android:autoSizeMinTextSize="9sp"
+                    android:autoSizeMaxTextSize="15sp"
+                    android:autoSizeStepGranularity="1sp" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/supplies_widget_row_1"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <ImageView
+                android:id="@+id/supplies_widget_icon_1"
+                android:layout_width="16dp"
+                android:layout_height="16dp"
+                android:layout_marginEnd="8dp"
+                android:src="@drawable/ic_widget_inventory"
+                android:contentDescription="@null" />
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:gravity="center_vertical">
+
+                <TextView
+                    android:id="@+id/supplies_widget_name_1"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/hrt_widget_title_text"
+                    android:textStyle="bold"
+                    android:textSize="13sp"
+                    android:maxLines="1"
+                    android:ellipsize="end"
+                    android:autoSizeTextType="uniform"
+                    android:autoSizeMinTextSize="10sp"
+                    android:autoSizeMaxTextSize="18sp"
+                    android:autoSizeStepGranularity="1sp" />
+
+                <TextView
+                    android:id="@+id/supplies_widget_summary_1"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/hrt_widget_subtitle_text"
+                    android:textSize="11sp"
+                    android:maxLines="1"
+                    android:ellipsize="end"
+                    android:autoSizeTextType="uniform"
+                    android:autoSizeMinTextSize="9sp"
+                    android:autoSizeMaxTextSize="15sp"
+                    android:autoSizeStepGranularity="1sp" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/supplies_widget_row_2"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <ImageView
+                android:id="@+id/supplies_widget_icon_2"
+                android:layout_width="16dp"
+                android:layout_height="16dp"
+                android:layout_marginEnd="8dp"
+                android:src="@drawable/ic_widget_inventory"
+                android:contentDescription="@null" />
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:gravity="center_vertical">
+
+                <TextView
+                    android:id="@+id/supplies_widget_name_2"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/hrt_widget_title_text"
+                    android:textStyle="bold"
+                    android:textSize="13sp"
+                    android:maxLines="1"
+                    android:ellipsize="end"
+                    android:autoSizeTextType="uniform"
+                    android:autoSizeMinTextSize="10sp"
+                    android:autoSizeMaxTextSize="18sp"
+                    android:autoSizeStepGranularity="1sp" />
+
+                <TextView
+                    android:id="@+id/supplies_widget_summary_2"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/hrt_widget_subtitle_text"
+                    android:textSize="11sp"
+                    android:maxLines="1"
+                    android:ellipsize="end"
+                    android:autoSizeTextType="uniform"
+                    android:autoSizeMinTextSize="9sp"
+                    android:autoSizeMaxTextSize="15sp"
+                    android:autoSizeStepGranularity="1sp" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/supplies_widget_row_3"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <ImageView
+                android:id="@+id/supplies_widget_icon_3"
+                android:layout_width="16dp"
+                android:layout_height="16dp"
+                android:layout_marginEnd="8dp"
+                android:src="@drawable/ic_widget_inventory"
+                android:contentDescription="@null" />
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:gravity="center_vertical">
+
+                <TextView
+                    android:id="@+id/supplies_widget_name_3"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/hrt_widget_title_text"
+                    android:textStyle="bold"
+                    android:textSize="13sp"
+                    android:maxLines="1"
+                    android:ellipsize="end"
+                    android:autoSizeTextType="uniform"
+                    android:autoSizeMinTextSize="10sp"
+                    android:autoSizeMaxTextSize="18sp"
+                    android:autoSizeStepGranularity="1sp" />
+
+                <TextView
+                    android:id="@+id/supplies_widget_summary_3"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/hrt_widget_subtitle_text"
+                    android:textSize="11sp"
+                    android:maxLines="1"
+                    android:ellipsize="end"
+                    android:autoSizeTextType="uniform"
+                    android:autoSizeMinTextSize="9sp"
+                    android:autoSizeMaxTextSize="15sp"
+                    android:autoSizeStepGranularity="1sp" />
+            </LinearLayout>
+        </LinearLayout>
+    </LinearLayout>
+</FrameLayout>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -2,15 +2,23 @@
 <resources>
     <color name="ic_launcher_background">#fef2e2</color>
 
-    <!-- Shared home screen widget card style (HRT progress, Next dose,
-         Recent injections all use the same look) -->
-    <color name="hrt_widget_card_background">#1E2318</color>
-    <color name="hrt_widget_icon_background">#F6DFA0</color>
-    <color name="hrt_widget_icon_foreground">#3A3320</color>
-    <color name="hrt_widget_title_text">#F2F4EA</color>
-    <color name="hrt_widget_subtitle_text">#8D9280</color>
+    <!--
+      Shared home screen widget card style (HRT progress, Next dose, Recent
+      injections all use the same look).
 
-    <!-- Next dose widget: overdue accent, swapped in for the icon circle -->
-    <color name="widget_overdue_icon_background">#F2A38B</color>
-    <color name="widget_overdue_icon_foreground">#4A2015</color>
+      These are fallback colors only, used for the widget picker's preview
+      and before the app has synced once. Once running, WidgetThemeService
+      (lib/services/widget_theme_service.dart) pushes the app's *actual*
+      current ColorScheme, including Material You dynamic color and custom
+      themes, and WidgetColors.kt applies it at runtime, so the values
+      below just mirror Mona's default (non-dynamic) light scheme
+      (see lib/theme/default_color_schemes.dart) as a sane starting point.
+    -->
+    <color name="hrt_widget_card_background">#F9E8FF</color>
+    <color name="hrt_widget_icon_background">#FF9CB5</color>
+    <color name="hrt_widget_icon_foreground">#710033</color>
+    <color name="hrt_widget_title_text">#40294F</color>
+    <color name="hrt_widget_subtitle_text">#6E557F</color>
+    <color name="widget_overdue_icon_background">#F76A80</color>
+    <color name="widget_overdue_icon_foreground">#68001F</color>
 </resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="ic_launcher_background">#fef2e2</color>
+
+    <!-- HRT progress widget -->
+    <color name="hrt_widget_card_background">#1E2318</color>
+    <color name="hrt_widget_icon_background">#F6DFA0</color>
+    <color name="hrt_widget_icon_foreground">#3A3320</color>
+    <color name="hrt_widget_title_text">#F2F4EA</color>
+    <color name="hrt_widget_subtitle_text">#8D9280</color>
 </resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -2,10 +2,15 @@
 <resources>
     <color name="ic_launcher_background">#fef2e2</color>
 
-    <!-- HRT progress widget -->
+    <!-- Shared home screen widget card style (HRT progress, Next dose,
+         Recent injections all use the same look) -->
     <color name="hrt_widget_card_background">#1E2318</color>
     <color name="hrt_widget_icon_background">#F6DFA0</color>
     <color name="hrt_widget_icon_foreground">#3A3320</color>
     <color name="hrt_widget_title_text">#F2F4EA</color>
     <color name="hrt_widget_subtitle_text">#8D9280</color>
+
+    <!-- Next dose widget: overdue accent, swapped in for the icon circle -->
+    <color name="widget_overdue_icon_background">#F2A38B</color>
+    <color name="widget_overdue_icon_foreground">#4A2015</color>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4,4 +4,14 @@
     <string name="hrt_widget_description">Shows how long you\'ve been on HRT and how many intakes you\'ve logged.</string>
     <string name="hrt_widget_default_title">On HRT for —</string>
     <string name="hrt_widget_default_subtitle">Open Mona to get started</string>
+
+    <string name="next_dose_widget_label">Next dose</string>
+    <string name="next_dose_widget_description">Shows whichever medication is next due, or overdue.</string>
+    <string name="next_dose_widget_default_title">Next dose</string>
+    <string name="next_dose_widget_default_subtitle">Open Mona to get started</string>
+
+    <string name="recent_intakes_widget_label">Recent injections</string>
+    <string name="recent_intakes_widget_description">Shows your most recently logged intakes.</string>
+    <string name="recent_intakes_widget_title">Recent injections</string>
+    <string name="recent_intakes_widget_empty">Taken intakes will appear here</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -14,4 +14,15 @@
     <string name="recent_intakes_widget_description">Shows your most recently logged intakes.</string>
     <string name="recent_intakes_widget_title">Recent injections</string>
     <string name="recent_intakes_widget_empty">Taken intakes will appear here</string>
+
+    <string name="status_widget_label">Status</string>
+    <string name="status_widget_description">A quick dashboard: HRT duration, next dose, and your most urgent supply.</string>
+    <string name="status_widget_default_duration">On HRT for —</string>
+    <string name="status_widget_default_next_dose">Next dose</string>
+    <string name="status_widget_default_supply">Supplies</string>
+
+    <string name="supplies_widget_label">Supplies</string>
+    <string name="supplies_widget_description">Shows the supply items running lowest.</string>
+    <string name="supplies_widget_title">Supplies</string>
+    <string name="supplies_widget_empty">Tracked supplies will appear here</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="hrt_widget_label">HRT progress</string>
+    <string name="hrt_widget_description">Shows how long you\'ve been on HRT and how many intakes you\'ve logged.</string>
+    <string name="hrt_widget_default_title">On HRT for —</string>
+    <string name="hrt_widget_default_subtitle">Open Mona to get started</string>
+</resources>

--- a/android/app/src/main/res/xml/hrt_widget_info.xml
+++ b/android/app/src/main/res/xml/hrt_widget_info.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="180dp"
+    android:minHeight="70dp"
+    android:targetCellWidth="4"
+    android:targetCellHeight="1"
+    android:updatePeriodMillis="0"
+    android:initialLayout="@layout/hrt_widget"
+    android:previewLayout="@layout/hrt_widget"
+    android:description="@string/hrt_widget_description"
+    android:widgetCategory="home_screen"
+    android:resizeMode="horizontal|vertical" />

--- a/android/app/src/main/res/xml/next_dose_widget_info.xml
+++ b/android/app/src/main/res/xml/next_dose_widget_info.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="180dp"
+    android:minHeight="70dp"
+    android:targetCellWidth="4"
+    android:targetCellHeight="1"
+    android:updatePeriodMillis="0"
+    android:initialLayout="@layout/next_dose_widget"
+    android:previewLayout="@layout/next_dose_widget"
+    android:description="@string/next_dose_widget_description"
+    android:widgetCategory="home_screen"
+    android:resizeMode="horizontal|vertical" />

--- a/android/app/src/main/res/xml/recent_intakes_widget_info.xml
+++ b/android/app/src/main/res/xml/recent_intakes_widget_info.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="250dp"
+    android:minHeight="180dp"
+    android:targetCellWidth="4"
+    android:targetCellHeight="3"
+    android:updatePeriodMillis="0"
+    android:initialLayout="@layout/recent_intakes_widget"
+    android:previewLayout="@layout/recent_intakes_widget"
+    android:description="@string/recent_intakes_widget_description"
+    android:widgetCategory="home_screen"
+    android:resizeMode="horizontal|vertical" />

--- a/android/app/src/main/res/xml/status_widget_info.xml
+++ b/android/app/src/main/res/xml/status_widget_info.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="180dp"
+    android:minHeight="180dp"
+    android:targetCellWidth="3"
+    android:targetCellHeight="3"
+    android:updatePeriodMillis="0"
+    android:initialLayout="@layout/status_widget"
+    android:previewLayout="@layout/status_widget"
+    android:description="@string/status_widget_description"
+    android:widgetCategory="home_screen"
+    android:resizeMode="horizontal|vertical" />

--- a/android/app/src/main/res/xml/supplies_widget_info.xml
+++ b/android/app/src/main/res/xml/supplies_widget_info.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="180dp"
+    android:minHeight="110dp"
+    android:targetCellWidth="3"
+    android:targetCellHeight="2"
+    android:updatePeriodMillis="0"
+    android:initialLayout="@layout/supplies_widget"
+    android:previewLayout="@layout/supplies_widget"
+    android:description="@string/supplies_widget_description"
+    android:widgetCategory="home_screen"
+    android:resizeMode="horizontal|vertical" />

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=false
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -10,8 +10,10 @@ import 'package:mona/i18n/build_context_extensions.dart';
 import 'package:mona/i18n/locale_provider.dart';
 import 'package:mona/i18n/tok_localizations.dart';
 import 'package:mona/services/hrt_widget_service.dart';
+import 'package:mona/services/next_dose_widget_service.dart';
 import 'package:mona/services/notification_service.dart';
 import 'package:mona/services/preferences_service.dart';
+import 'package:mona/services/recent_intakes_widget_service.dart';
 import 'package:mona/theme/app_theme_controller.dart';
 import 'package:provider/provider.dart';
 import 'ui/views/main_page.dart';
@@ -30,6 +32,8 @@ class _MonaAppState extends State<MonaApp> with WidgetsBindingObserver {
   late PreferencesService _preferencesService;
   late NotificationScheduler _notificationScheduler;
   late HrtWidgetService _hrtWidgetService;
+  late NextDoseWidgetService _nextDoseWidgetService;
+  late RecentIntakesWidgetService _recentIntakesWidgetService;
 
   @override
   void initState() {
@@ -52,13 +56,21 @@ class _MonaAppState extends State<MonaApp> with WidgetsBindingObserver {
         medicationIntakeProvider: _medicationIntakeProvider,
         preferencesService: _preferencesService,
       );
+      _nextDoseWidgetService = NextDoseWidgetService(
+        medicationIntakeProvider: _medicationIntakeProvider,
+        medicationScheduleProvider: _medicationScheduleProvider,
+      );
+      _recentIntakesWidgetService = RecentIntakesWidgetService(
+        medicationIntakeProvider: _medicationIntakeProvider,
+      );
       _medicationScheduleProvider.addListener(_regenerateNotifications);
       _medicationIntakeProvider.addListener(_regenerateNotifications);
       _preferencesService.addListener(_regenerateNotifications);
-      _medicationIntakeProvider.addListener(_updateHomeWidget);
-      _preferencesService.addListener(_updateHomeWidget);
+      _medicationIntakeProvider.addListener(_updateHomeWidgets);
+      _preferencesService.addListener(_updateHomeWidgets);
+      _medicationScheduleProvider.addListener(_updateHomeWidgets);
       _regenerateNotifications();
-      _updateHomeWidget();
+      _updateHomeWidgets();
     });
   }
 
@@ -68,8 +80,9 @@ class _MonaAppState extends State<MonaApp> with WidgetsBindingObserver {
     _medicationScheduleProvider.removeListener(_regenerateNotifications);
     _medicationIntakeProvider.removeListener(_regenerateNotifications);
     _preferencesService.removeListener(_regenerateNotifications);
-    _medicationIntakeProvider.removeListener(_updateHomeWidget);
-    _preferencesService.removeListener(_updateHomeWidget);
+    _medicationIntakeProvider.removeListener(_updateHomeWidgets);
+    _preferencesService.removeListener(_updateHomeWidgets);
+    _medicationScheduleProvider.removeListener(_updateHomeWidgets);
     super.dispose();
   }
 
@@ -80,8 +93,10 @@ class _MonaAppState extends State<MonaApp> with WidgetsBindingObserver {
     _notificationScheduler.regenerateAll(locale.intlLanguageTag);
   }
 
-  void _updateHomeWidget() {
+  void _updateHomeWidgets() {
     _hrtWidgetService.sync();
+    _nextDoseWidgetService.sync();
+    _recentIntakesWidgetService.sync();
   }
 
   void _checkTimezoneChange() {

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -5,6 +5,7 @@ import 'package:mona/controllers/notification_planner.dart';
 import 'package:mona/controllers/notification_scheduler.dart';
 import 'package:mona/data/providers/medication_intake_provider.dart';
 import 'package:mona/data/providers/medication_schedule_provider.dart';
+import 'package:mona/data/providers/supply_item_provider.dart';
 import 'package:mona/distribution.dart';
 import 'package:mona/i18n/build_context_extensions.dart';
 import 'package:mona/i18n/locale_provider.dart';
@@ -14,6 +15,8 @@ import 'package:mona/services/next_dose_widget_service.dart';
 import 'package:mona/services/notification_service.dart';
 import 'package:mona/services/preferences_service.dart';
 import 'package:mona/services/recent_intakes_widget_service.dart';
+import 'package:mona/services/status_widget_service.dart';
+import 'package:mona/services/supplies_widget_service.dart';
 import 'package:mona/services/widget_theme_service.dart';
 import 'package:mona/theme/app_theme_controller.dart';
 import 'package:provider/provider.dart';
@@ -30,11 +33,14 @@ class _MonaAppState extends State<MonaApp> with WidgetsBindingObserver {
   String? _lastTimeZone;
   late MedicationScheduleProvider _medicationScheduleProvider;
   late MedicationIntakeProvider _medicationIntakeProvider;
+  late SupplyItemProvider _supplyItemProvider;
   late PreferencesService _preferencesService;
   late NotificationScheduler _notificationScheduler;
   late HrtWidgetService _hrtWidgetService;
   late NextDoseWidgetService _nextDoseWidgetService;
   late RecentIntakesWidgetService _recentIntakesWidgetService;
+  late StatusWidgetService _statusWidgetService;
+  late SuppliesWidgetService _suppliesWidgetService;
   final WidgetThemeService _widgetThemeService = WidgetThemeService();
 
   @override
@@ -48,6 +54,7 @@ class _MonaAppState extends State<MonaApp> with WidgetsBindingObserver {
       if (!mounted) return;
       _medicationScheduleProvider = context.read<MedicationScheduleProvider>();
       _medicationIntakeProvider = context.read<MedicationIntakeProvider>();
+      _supplyItemProvider = context.read<SupplyItemProvider>();
       _preferencesService = context.read<PreferencesService>();
       _notificationScheduler = NotificationScheduler(
         NotificationPlanner(
@@ -65,12 +72,21 @@ class _MonaAppState extends State<MonaApp> with WidgetsBindingObserver {
       _recentIntakesWidgetService = RecentIntakesWidgetService(
         medicationIntakeProvider: _medicationIntakeProvider,
       );
+      _statusWidgetService = StatusWidgetService(
+        medicationIntakeProvider: _medicationIntakeProvider,
+        medicationScheduleProvider: _medicationScheduleProvider,
+        supplyItemProvider: _supplyItemProvider,
+      );
+      _suppliesWidgetService = SuppliesWidgetService(
+        supplyItemProvider: _supplyItemProvider,
+      );
       _medicationScheduleProvider.addListener(_regenerateNotifications);
       _medicationIntakeProvider.addListener(_regenerateNotifications);
       _preferencesService.addListener(_regenerateNotifications);
       _medicationIntakeProvider.addListener(_updateHomeWidgets);
       _preferencesService.addListener(_updateHomeWidgets);
       _medicationScheduleProvider.addListener(_updateHomeWidgets);
+      _supplyItemProvider.addListener(_updateHomeWidgets);
       _regenerateNotifications();
       _updateHomeWidgets();
     });
@@ -85,6 +101,7 @@ class _MonaAppState extends State<MonaApp> with WidgetsBindingObserver {
     _medicationIntakeProvider.removeListener(_updateHomeWidgets);
     _preferencesService.removeListener(_updateHomeWidgets);
     _medicationScheduleProvider.removeListener(_updateHomeWidgets);
+    _supplyItemProvider.removeListener(_updateHomeWidgets);
     super.dispose();
   }
 
@@ -99,6 +116,8 @@ class _MonaAppState extends State<MonaApp> with WidgetsBindingObserver {
     _hrtWidgetService.sync();
     _nextDoseWidgetService.sync();
     _recentIntakesWidgetService.sync();
+    _statusWidgetService.sync();
+    _suppliesWidgetService.sync();
   }
 
   void _checkTimezoneChange() {

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -9,6 +9,7 @@ import 'package:mona/distribution.dart';
 import 'package:mona/i18n/build_context_extensions.dart';
 import 'package:mona/i18n/locale_provider.dart';
 import 'package:mona/i18n/tok_localizations.dart';
+import 'package:mona/services/hrt_widget_service.dart';
 import 'package:mona/services/notification_service.dart';
 import 'package:mona/services/preferences_service.dart';
 import 'package:mona/theme/app_theme_controller.dart';
@@ -28,6 +29,7 @@ class _MonaAppState extends State<MonaApp> with WidgetsBindingObserver {
   late MedicationIntakeProvider _medicationIntakeProvider;
   late PreferencesService _preferencesService;
   late NotificationScheduler _notificationScheduler;
+  late HrtWidgetService _hrtWidgetService;
 
   @override
   void initState() {
@@ -46,10 +48,17 @@ class _MonaAppState extends State<MonaApp> with WidgetsBindingObserver {
             _medicationIntakeProvider, _medicationScheduleProvider),
         _preferencesService,
       );
+      _hrtWidgetService = HrtWidgetService(
+        medicationIntakeProvider: _medicationIntakeProvider,
+        preferencesService: _preferencesService,
+      );
       _medicationScheduleProvider.addListener(_regenerateNotifications);
       _medicationIntakeProvider.addListener(_regenerateNotifications);
       _preferencesService.addListener(_regenerateNotifications);
+      _medicationIntakeProvider.addListener(_updateHomeWidget);
+      _preferencesService.addListener(_updateHomeWidget);
       _regenerateNotifications();
+      _updateHomeWidget();
     });
   }
 
@@ -59,6 +68,8 @@ class _MonaAppState extends State<MonaApp> with WidgetsBindingObserver {
     _medicationScheduleProvider.removeListener(_regenerateNotifications);
     _medicationIntakeProvider.removeListener(_regenerateNotifications);
     _preferencesService.removeListener(_regenerateNotifications);
+    _medicationIntakeProvider.removeListener(_updateHomeWidget);
+    _preferencesService.removeListener(_updateHomeWidget);
     super.dispose();
   }
 
@@ -67,6 +78,10 @@ class _MonaAppState extends State<MonaApp> with WidgetsBindingObserver {
 
     final locale = context.read<LocaleProvider>().locale;
     _notificationScheduler.regenerateAll(locale.intlLanguageTag);
+  }
+
+  void _updateHomeWidget() {
+    _hrtWidgetService.sync();
   }
 
   void _checkTimezoneChange() {

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -14,6 +14,7 @@ import 'package:mona/services/next_dose_widget_service.dart';
 import 'package:mona/services/notification_service.dart';
 import 'package:mona/services/preferences_service.dart';
 import 'package:mona/services/recent_intakes_widget_service.dart';
+import 'package:mona/services/widget_theme_service.dart';
 import 'package:mona/theme/app_theme_controller.dart';
 import 'package:provider/provider.dart';
 import 'ui/views/main_page.dart';
@@ -34,6 +35,7 @@ class _MonaAppState extends State<MonaApp> with WidgetsBindingObserver {
   late HrtWidgetService _hrtWidgetService;
   late NextDoseWidgetService _nextDoseWidgetService;
   late RecentIntakesWidgetService _recentIntakesWidgetService;
+  final WidgetThemeService _widgetThemeService = WidgetThemeService();
 
   @override
   void initState() {
@@ -123,6 +125,13 @@ class _MonaAppState extends State<MonaApp> with WidgetsBindingObserver {
               systemLight: lightDynamic,
               systemDark: darkDynamic,
             );
+
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          _widgetThemeService.sync(
+            light: themes.theme.colorScheme,
+            dark: themes.darkTheme.colorScheme,
+          );
+        });
 
         return MaterialApp(
           title: 'Mona',

--- a/lib/controllers/next_dose_resolver.dart
+++ b/lib/controllers/next_dose_resolver.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:mona/controllers/slots_builder.dart';
+import 'package:mona/data/model/date.dart';
+import 'package:mona/data/model/intake_slot.dart';
+import 'package:mona/data/model/scheduling_strategy.dart';
+import 'package:mona/data/providers/medication_intake_provider.dart';
+import 'package:mona/data/providers/medication_schedule_provider.dart';
+import 'package:mona/i18n/build_context_extensions.dart';
+import 'package:mona/i18n/translations.g.dart';
+
+/// Picks whichever schedule is next due (or overdue) across all of a user's
+/// schedules, and renders a short localized timing label for it.
+///
+/// Pure logic, no BuildContext or platform dependency, so it can back both
+/// [NextDoseWidgetService] and [StatusWidgetService] without either
+/// duplicating (and risking drifting out of sync with) the urgency ranking.
+class NextDoseResolver {
+  const NextDoseResolver();
+
+  /// Picks the single most urgent slot that hasn't been taken yet: overdue
+  /// first (oldest miss first), then today, then the soonest upcoming
+  /// occurrence. Returns null when every schedule is caught up.
+  IntakeSlot? pickNext(
+    MedicationIntakeProvider medicationIntakeProvider,
+    MedicationScheduleProvider medicationScheduleProvider,
+  ) {
+    final slots = SlotsBuilder(
+      medicationIntakeProvider,
+      medicationScheduleProvider,
+    ).intakeSlots();
+
+    final pending = slots
+        .where((s) => s.status != ScheduleStatus.taken)
+        .toList()
+      ..sort(_compareUrgency);
+    return pending.isEmpty ? null : pending.first;
+  }
+
+  bool isOverdue(IntakeSlot slot) =>
+      slot.status == ScheduleStatus.overdue ||
+      slot.status == ScheduleStatus.todayOverdue;
+
+  int _compareUrgency(IntakeSlot a, IntakeSlot b) {
+    final rankCompare = _rank(a.status).compareTo(_rank(b.status));
+    if (rankCompare != 0) return rankCompare;
+
+    if (a.date != b.date) {
+      return a.date.isBefore(b.date) ? -1 : 1;
+    }
+
+    final at = a.time;
+    final bt = b.time;
+    if (at == null && bt == null) return 0;
+    if (at == null) return -1;
+    if (bt == null) return 1;
+    final hourCompare = at.hour.compareTo(bt.hour);
+    return hourCompare != 0 ? hourCompare : at.minute.compareTo(bt.minute);
+  }
+
+  int _rank(ScheduleStatus status) => switch (status) {
+        ScheduleStatus.overdue || ScheduleStatus.todayOverdue => 0,
+        ScheduleStatus.todayEarly || ScheduleStatus.today => 1,
+        ScheduleStatus.upcoming => 2,
+        ScheduleStatus.taken => 3,
+      };
+
+  /// A short "when" label: "Overdue", "Due today", a formatted time, or a
+  /// relative date like "Tomorrow" / "in 3 days".
+  String timingLabel(IntakeSlot slot) {
+    switch (slot.status) {
+      case ScheduleStatus.overdue:
+      case ScheduleStatus.todayOverdue:
+        return t.nextDoseOverdueLabel;
+      case ScheduleStatus.todayEarly:
+      case ScheduleStatus.today:
+        final time = slot.time;
+        return time == null ? t.nextDoseDueTodayLabel : _formatTime(time);
+      case ScheduleStatus.upcoming:
+        return _upcomingLabel(slot.date);
+      case ScheduleStatus.taken:
+        return '';
+    }
+  }
+
+  String _upcomingLabel(Date date) {
+    final diff = date.daysAwayFromToday;
+    if (diff == 1) {
+      final tomorrow = t.tomorrow;
+      return tomorrow[0].toUpperCase() + tomorrow.substring(1);
+    }
+    return t.inDaysCount(count: diff);
+  }
+
+  String _formatTime(TimeOfDay time) {
+    final dt = DateTime(2000, 1, 1, time.hour, time.minute);
+    return DateFormat.jm(_languageTag).format(dt);
+  }
+
+  String get _languageTag =>
+      intlSafeLanguageTag(LocaleSettings.currentLocale.languageTag);
+}

--- a/lib/i18n/en.i18next.json
+++ b/lib/i18n/en.i18next.json
@@ -19,6 +19,8 @@
   "tomorrow": "tomorrow",
   "lastTaken": "Last taken",
   "neverTakenYet": "Never taken yet",
+  "nextDoseOverdueLabel": "Overdue",
+  "nextDoseDueTodayLabel": "Due today",
   "scheduleFrequencyDaily": "Every day",
   "scheduleFrequencyEveryNDays_one": "Every day",
   "scheduleFrequencyEveryNDays_other": "Every {{count}} days",

--- a/lib/i18n/helpers/hrt_duration_l10n.dart
+++ b/lib/i18n/helpers/hrt_duration_l10n.dart
@@ -1,0 +1,11 @@
+import 'package:mona/i18n/translations.g.dart';
+import 'package:mona/util/hrt_duration.dart';
+
+extension HrtDurationL10n on HrtDuration {
+  String get localizedText => switch (unit) {
+        HrtDurationUnit.days => t.onHrtForDays(count: value),
+        HrtDurationUnit.weeks => t.onHrtForWeeks(count: value),
+        HrtDurationUnit.months => t.onHrtForMonths(count: value),
+        HrtDurationUnit.years => t.onHrtForYears(count: value),
+      };
+}

--- a/lib/i18n/translations.g.dart
+++ b/lib/i18n/translations.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 18
-/// Strings: 3462 (192 per locale)
+/// Strings: 3576 (198 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/translations_en.g.dart
+++ b/lib/i18n/translations_en.g.dart
@@ -99,6 +99,12 @@ class Translations with BaseTranslations<AppLocale, Translations> {
   /// en: 'Never taken yet'
   String get neverTakenYet => 'Never taken yet';
 
+  /// en: 'Overdue'
+  String get nextDoseOverdueLabel => 'Overdue';
+
+  /// en: 'Due today'
+  String get nextDoseDueTodayLabel => 'Due today';
+
   /// en: 'Every day'
   String get scheduleFrequencyDaily => 'Every day';
 
@@ -1002,6 +1008,8 @@ extension on Translations {
       'tomorrow' => 'tomorrow',
       'lastTaken' => 'Last taken',
       'neverTakenYet' => 'Never taken yet',
+      'nextDoseOverdueLabel' => 'Overdue',
+      'nextDoseDueTodayLabel' => 'Due today',
       'scheduleFrequencyDaily' => 'Every day',
       'scheduleFrequencyInterval' => 'Interval',
       'scheduleFrequencyWeekly' => 'Weekly',

--- a/lib/i18n/translations_fr.g.dart
+++ b/lib/i18n/translations_fr.g.dart
@@ -614,6 +614,7 @@ class TranslationsFr extends Translations
       (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('fr'))(
         count,
         one: '1 jour sous THS',
+        many: '${count} de jours sous THS',
         other: '${count} jours sous THS',
       );
   @override
@@ -621,6 +622,7 @@ class TranslationsFr extends Translations
       (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('fr'))(
         count,
         one: '1 semaine sous THS',
+        many: '${count} de semaines sous THS',
         other: '${count} semaines sous THS',
       );
   @override
@@ -628,6 +630,7 @@ class TranslationsFr extends Translations
       (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('fr'))(
         count,
         one: '1 mois sous THS',
+        many: '${count} de mois sous THS',
         other: '${count} mois sous THS',
       );
   @override
@@ -635,6 +638,7 @@ class TranslationsFr extends Translations
       (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('fr'))(
         count,
         one: '1 an sous THS',
+        many: '${count} d\'années sous THS',
         other: '${count} ans sous THS',
       );
   @override
@@ -642,6 +646,7 @@ class TranslationsFr extends Translations
       (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('fr'))(
         count,
         one: '1 prise enregistrée',
+        many: '${count} de prises enregistrées',
         other: '${count} prises enregistrées',
       );
   @override
@@ -1072,30 +1077,35 @@ extension on TranslationsFr {
           (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('fr'))(
             count,
             one: '1 jour sous THS',
+            many: '${count} de jours sous THS',
             other: '${count} jours sous THS',
           ),
       'onHrtForWeeks' => ({required num count}) =>
           (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('fr'))(
             count,
             one: '1 semaine sous THS',
+            many: '${count} de semaines sous THS',
             other: '${count} semaines sous THS',
           ),
       'onHrtForMonths' => ({required num count}) =>
           (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('fr'))(
             count,
             one: '1 mois sous THS',
+            many: '${count} de mois sous THS',
             other: '${count} mois sous THS',
           ),
       'onHrtForYears' => ({required num count}) =>
           (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('fr'))(
             count,
             one: '1 an sous THS',
+            many: '${count} d\'années sous THS',
             other: '${count} ans sous THS',
           ),
       'intakesLoggedCount' => ({required num count}) =>
           (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('fr'))(
             count,
             one: '1 prise enregistrée',
+            many: '${count} de prises enregistrées',
             other: '${count} prises enregistrées',
           ),
       'remaining' => ({required num count, required Object unit}) =>

--- a/lib/i18n/translations_nl.g.dart
+++ b/lib/i18n/translations_nl.g.dart
@@ -59,6 +59,266 @@ class TranslationsNl extends Translations
   String get nav_home => 'Mona';
   @override
   String get nav_intakes => 'Innamens';
+  @override
+  String get nav_levels => 'Waarden';
+  @override
+  String get nav_supplies => 'Middelen';
+  @override
+  String get takeAnIntake => 'Dosis toevoegen';
+  @override
+  String get addAnItem => 'Item toevoegen';
+  @override
+  String get empty_home =>
+      'Begin door een planning toe te voegen in de Instellingen';
+  @override
+  String get allDone => 'Afgerond!';
+  @override
+  String get noIntakesDue => 'Geen innamens voor vandaag';
+  @override
+  String get upcoming => 'Aankomend';
+  @override
+  String get taken => 'Genomen';
+  @override
+  String get yesterday => 'gisteren';
+  @override
+  String get tomorrow => 'morgen';
+  @override
+  String get scheduleFrequencyDaily => 'Elke dag';
+  @override
+  String get scheduleFrequencyWeekly => 'Wekelijks';
+  @override
+  String get scheduleFrequencyMonthly => 'Maandelijks';
+  @override
+  String get newUpdateAvailable => 'Een nieuwe update is beschikbaar!';
+  @override
+  String get goToSettings => 'Ga naar Instellingen';
+  @override
+  String get settingsTitle => 'Instellingen';
+  @override
+  String get notifications => 'Meldingen';
+  @override
+  String get schedulesAndNotifications => 'Planning & meldingen';
+  @override
+  String get general => 'Algemeen';
+  @override
+  String get schedules => 'Planning';
+  @override
+  String get noSchedules => 'Geen geplande momenten';
+  @override
+  String get language => 'Taal';
+  @override
+  String get languageFollowDevice => 'Apparaattaal volgen';
+  @override
+  String get selectLanguage => 'Taal Selecteren';
+  @override
+  String get enableNotifications => 'Meldingen aanzetten';
+  @override
+  String get enableNotificationsDescription => 'Reminders verzenden';
+  @override
+  String get notificationsDisabledTitle => 'Meldingen staan uit';
+  @override
+  String get clickToOpenSettings => 'Klik om instellingen te openen';
+  @override
+  String get exactRemindersDisabled => 'Exacte tijden voor reminders staan uit';
+  @override
+  String get remindersDelayed =>
+      'Reminders kunnen misschien een beetje later aankomen. Klik om instellingen te openen.';
+  @override
+  String get medicalSettings => 'Medische instellingen';
+  @override
+  String get theme => 'Thema';
+  @override
+  String get themeCustomizeColors => 'Appkleuren aanpassen';
+  @override
+  String get customThemeEnabled => 'Aangepast thema';
+  @override
+  String get themeGenerate => 'Genereer';
+  @override
+  String get themeVariant => 'Variant';
+  @override
+  String get themeContrast => 'Contrast';
+  @override
+  String get themeContrastStandard => 'Standaard';
+  @override
+  String get themeContrastMedium => 'Medium';
+  @override
+  String get themeContrastHigh => 'Hoog';
+  @override
+  String get autoUpdate => 'Automatisch Updaten';
+  @override
+  String get autoUpdateDescription =>
+      'Check automatisch of er een nieuwe app versie is wanneer de app opstart';
+  @override
+  String get checkForUpdates => 'Check voor Updates';
+  @override
+  String get checkForUpdatesDescription =>
+      'Handmatig controleren op de nieuwste versie\nEr wordt verbinding gemaakt met het internet\n(Er worden geen gegevens verzonden)';
+  @override
+  String appVersion({required Object version}) => 'Mona versie ${version}';
+  @override
+  String backupSavedTo({required Object path}) =>
+      'Backup opgeslagen in: ${path}';
+  @override
+  String exportFailed({required Object error}) =>
+      'Exporteren mislukt: ${error}';
+  @override
+  String get importDataTitle => 'Data importeren';
+  @override
+  String get importDataSubtitle => 'Data herstellen van een JSON backup';
+  @override
+  String get importDataOverwriteWarning =>
+      'Dit zal je oude data overschrijven met de backup. Deze actie kan niet teruggedraaid worden. Wil je toch doorgaan?';
+  @override
+  String get importConfirm => 'Importeren';
+  @override
+  String get importSuccessfulTitle => 'Succesvol geimporteerd';
+  @override
+  String get importRestartRequired =>
+      'Start de app opnieuw op om de nieuwe data in te laden.';
+  @override
+  String get closeApp => 'App Afsluiten';
+  @override
+  String importFailed({required Object error}) =>
+      'Importeren mislukt: ${error}';
+  @override
+  String get updates => 'Updates';
+  @override
+  String get dataManagement => 'Data Management';
+  @override
+  String get exportDataTitle => 'Data Exporteren';
+  @override
+  String get exportDataSubtitle => 'Sla je data op in een JSON bestand';
+  @override
+  String get units => 'Eenheden';
+  @override
+  String get updateNoCompatibleApk =>
+      'Er is geen geschikte update beschikbaar voor je apparaat.';
+  @override
+  String get updateAppUpToDate => 'Je gebruikt de nieuwste versie van de app!';
+  @override
+  String get updateCheckNetworkError =>
+      'Kan niet op nieuwe updates checken op dit moment.';
+  @override
+  String get updateDialogTitle => 'Update Beschikbaar';
+  @override
+  String updateDialogBody({required Object latest, required Object current}) =>
+      'Versie ${latest} is beschikbaar! (Huidige: ${current})\n\nEen geschikte update is klaar om te installeren voor je apparaat.';
+  @override
+  String get updateDownloadAndInstall => 'Download & Installeer';
+  @override
+  String get updateInstallPermissionRequired =>
+      'Een permissie is nodig om updates te kunnen installeren.';
+  @override
+  String get updateDownloadingTitle => 'Update Downloaden...';
+  @override
+  String updateFailedOpenInstaller({required Object message}) =>
+      'Openen van de installer mislukt: ${message}';
+  @override
+  String get updateDownloadFailed =>
+      'Download mislukt. Controlleer je internet connectie.';
+  @override
+  String notificationMedicationReminderBodyDate({required Object date}) =>
+      'Gepland voor ${date}';
+  @override
+  String notificationMedicationReminderBodyTime({required Object time}) =>
+      'Gepland voor ${time}';
+  @override
+  String notificationMedicationReminderBodyWeekday({required Object weekday}) =>
+      'Gepland voor ${weekday}';
+  @override
+  String get addSchedule => 'Planning toevoegen';
+  @override
+  String get addScheduleToGetStarted => 'Voeg een planning toe om te beginnen.';
+  @override
+  String get newSchedule => 'Nieuwe planning';
+  @override
+  String get every => 'Elke';
+  @override
+  String get days => 'dagen';
+  @override
+  String get dayOfMonth => 'Dag van de maand';
+  @override
+  String get months => 'maanden';
+  @override
+  String get startDate => 'Start datun';
+  @override
+  String get pickATime => 'Kies een tijd';
+  @override
+  String get addIntakeTime => 'Een tijd toevoegen';
+  @override
+  String get editScheduleInfo => 'Planning informatie bewerken';
+  @override
+  String get scheduling => 'Planning';
+  @override
+  String get editSchedule => 'Planning bewerken';
+  @override
+  String deleteSchedule({required Object name}) => '${name} verwijderen?';
+  @override
+  String get addNotification => 'Melding toevoegen';
+  @override
+  String daysAgoCount({required num count}) =>
+      (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+        count,
+        one: '${count} dag geleden',
+        other: '${count} dagen geleden',
+      );
+  @override
+  String inDaysCount({required num count}) =>
+      (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+        count,
+        one: 'over ${count} dag',
+        other: 'over ${count} dagen',
+      );
+  @override
+  String scheduleFrequencyEveryNDays({required num count}) =>
+      (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+        count,
+        one: 'Elke dag',
+        other: 'Elke ${count} dagen',
+      );
+  @override
+  String scheduleFrequencyOnDayEveryNMonths(
+          {required num count, required Object day}) =>
+      (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+        count,
+        one: 'Dag ${day}, elke maand',
+        other: 'Dag ${day}, elke ${count} maanden',
+      );
+  @override
+  String schedulesCreated({required num count}) =>
+      (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+        count,
+        one: '${count} aangemaakt',
+        other: '${count} aangemaakt',
+      );
+  @override
+  String onHrtForDays({required num count}) =>
+      (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+        count,
+        one: 'Aan HRT voor 1 dag',
+        other: 'Aan HRT voor ${count} dagen',
+      );
+  @override
+  String onHrtForWeeks({required num count}) =>
+      (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+        count,
+        one: 'Aan HRT voor 1 week',
+        other: 'Aan HRT voor ${count} weken',
+      );
+  @override
+  String onHrtForMonths({required num count}) =>
+      (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+        count,
+        one: 'Aan HRT voor 1 maand',
+        other: 'Aan HRT voor ${count} maanden',
+      );
+  @override
+  String onHrtForYears({required num count}) =>
+      (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+        count,
+        one: 'Aan HRT voor 1 jaar',
+        other: 'Aan HRT voor ${count} jaar',
+      );
 }
 
 /// The flat map containing all translations for locale <nl>.
@@ -72,6 +332,169 @@ extension on TranslationsNl {
       'appTitle' => 'Mona',
       'nav_home' => 'Mona',
       'nav_intakes' => 'Innamens',
+      'nav_levels' => 'Waarden',
+      'nav_supplies' => 'Middelen',
+      'takeAnIntake' => 'Dosis toevoegen',
+      'addAnItem' => 'Item toevoegen',
+      'empty_home' =>
+        'Begin door een planning toe te voegen in de Instellingen',
+      'allDone' => 'Afgerond!',
+      'noIntakesDue' => 'Geen innamens voor vandaag',
+      'upcoming' => 'Aankomend',
+      'taken' => 'Genomen',
+      'yesterday' => 'gisteren',
+      'tomorrow' => 'morgen',
+      'scheduleFrequencyDaily' => 'Elke dag',
+      'scheduleFrequencyWeekly' => 'Wekelijks',
+      'scheduleFrequencyMonthly' => 'Maandelijks',
+      'newUpdateAvailable' => 'Een nieuwe update is beschikbaar!',
+      'goToSettings' => 'Ga naar Instellingen',
+      'settingsTitle' => 'Instellingen',
+      'notifications' => 'Meldingen',
+      'schedulesAndNotifications' => 'Planning & meldingen',
+      'general' => 'Algemeen',
+      'schedules' => 'Planning',
+      'noSchedules' => 'Geen geplande momenten',
+      'language' => 'Taal',
+      'languageFollowDevice' => 'Apparaattaal volgen',
+      'selectLanguage' => 'Taal Selecteren',
+      'enableNotifications' => 'Meldingen aanzetten',
+      'enableNotificationsDescription' => 'Reminders verzenden',
+      'notificationsDisabledTitle' => 'Meldingen staan uit',
+      'clickToOpenSettings' => 'Klik om instellingen te openen',
+      'exactRemindersDisabled' => 'Exacte tijden voor reminders staan uit',
+      'remindersDelayed' =>
+        'Reminders kunnen misschien een beetje later aankomen. Klik om instellingen te openen.',
+      'medicalSettings' => 'Medische instellingen',
+      'theme' => 'Thema',
+      'themeCustomizeColors' => 'Appkleuren aanpassen',
+      'customThemeEnabled' => 'Aangepast thema',
+      'themeGenerate' => 'Genereer',
+      'themeVariant' => 'Variant',
+      'themeContrast' => 'Contrast',
+      'themeContrastStandard' => 'Standaard',
+      'themeContrastMedium' => 'Medium',
+      'themeContrastHigh' => 'Hoog',
+      'autoUpdate' => 'Automatisch Updaten',
+      'autoUpdateDescription' =>
+        'Check automatisch of er een nieuwe app versie is wanneer de app opstart',
+      'checkForUpdates' => 'Check voor Updates',
+      'checkForUpdatesDescription' =>
+        'Handmatig controleren op de nieuwste versie\nEr wordt verbinding gemaakt met het internet\n(Er worden geen gegevens verzonden)',
+      'appVersion' => ({required Object version}) => 'Mona versie ${version}',
+      'backupSavedTo' => ({required Object path}) =>
+          'Backup opgeslagen in: ${path}',
+      'exportFailed' => ({required Object error}) =>
+          'Exporteren mislukt: ${error}',
+      'importDataTitle' => 'Data importeren',
+      'importDataSubtitle' => 'Data herstellen van een JSON backup',
+      'importDataOverwriteWarning' =>
+        'Dit zal je oude data overschrijven met de backup. Deze actie kan niet teruggedraaid worden. Wil je toch doorgaan?',
+      'importConfirm' => 'Importeren',
+      'importSuccessfulTitle' => 'Succesvol geimporteerd',
+      'importRestartRequired' =>
+        'Start de app opnieuw op om de nieuwe data in te laden.',
+      'closeApp' => 'App Afsluiten',
+      'importFailed' => ({required Object error}) =>
+          'Importeren mislukt: ${error}',
+      'updates' => 'Updates',
+      'dataManagement' => 'Data Management',
+      'exportDataTitle' => 'Data Exporteren',
+      'exportDataSubtitle' => 'Sla je data op in een JSON bestand',
+      'units' => 'Eenheden',
+      'updateNoCompatibleApk' =>
+        'Er is geen geschikte update beschikbaar voor je apparaat.',
+      'updateAppUpToDate' => 'Je gebruikt de nieuwste versie van de app!',
+      'updateCheckNetworkError' =>
+        'Kan niet op nieuwe updates checken op dit moment.',
+      'updateDialogTitle' => 'Update Beschikbaar',
+      'updateDialogBody' => (
+              {required Object latest, required Object current}) =>
+          'Versie ${latest} is beschikbaar! (Huidige: ${current})\n\nEen geschikte update is klaar om te installeren voor je apparaat.',
+      'updateDownloadAndInstall' => 'Download & Installeer',
+      'updateInstallPermissionRequired' =>
+        'Een permissie is nodig om updates te kunnen installeren.',
+      'updateDownloadingTitle' => 'Update Downloaden...',
+      'updateFailedOpenInstaller' => ({required Object message}) =>
+          'Openen van de installer mislukt: ${message}',
+      'updateDownloadFailed' =>
+        'Download mislukt. Controlleer je internet connectie.',
+      'notificationMedicationReminderBodyDate' => ({required Object date}) =>
+          'Gepland voor ${date}',
+      'notificationMedicationReminderBodyTime' => ({required Object time}) =>
+          'Gepland voor ${time}',
+      'notificationMedicationReminderBodyWeekday' =>
+        ({required Object weekday}) => 'Gepland voor ${weekday}',
+      'addSchedule' => 'Planning toevoegen',
+      'addScheduleToGetStarted' => 'Voeg een planning toe om te beginnen.',
+      'newSchedule' => 'Nieuwe planning',
+      'every' => 'Elke',
+      'days' => 'dagen',
+      'dayOfMonth' => 'Dag van de maand',
+      'months' => 'maanden',
+      'startDate' => 'Start datun',
+      'pickATime' => 'Kies een tijd',
+      'addIntakeTime' => 'Een tijd toevoegen',
+      'editScheduleInfo' => 'Planning informatie bewerken',
+      'scheduling' => 'Planning',
+      'editSchedule' => 'Planning bewerken',
+      'deleteSchedule' => ({required Object name}) => '${name} verwijderen?',
+      'addNotification' => 'Melding toevoegen',
+      'daysAgoCount' => ({required num count}) =>
+          (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+            count,
+            one: '${count} dag geleden',
+            other: '${count} dagen geleden',
+          ),
+      'inDaysCount' => ({required num count}) =>
+          (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+            count,
+            one: 'over ${count} dag',
+            other: 'over ${count} dagen',
+          ),
+      'scheduleFrequencyEveryNDays' => ({required num count}) =>
+          (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+            count,
+            one: 'Elke dag',
+            other: 'Elke ${count} dagen',
+          ),
+      'scheduleFrequencyOnDayEveryNMonths' => (
+              {required num count, required Object day}) =>
+          (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+            count,
+            one: 'Dag ${day}, elke maand',
+            other: 'Dag ${day}, elke ${count} maanden',
+          ),
+      'schedulesCreated' => ({required num count}) =>
+          (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+            count,
+            one: '${count} aangemaakt',
+            other: '${count} aangemaakt',
+          ),
+      'onHrtForDays' => ({required num count}) =>
+          (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+            count,
+            one: 'Aan HRT voor 1 dag',
+            other: 'Aan HRT voor ${count} dagen',
+          ),
+      'onHrtForWeeks' => ({required num count}) =>
+          (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+            count,
+            one: 'Aan HRT voor 1 week',
+            other: 'Aan HRT voor ${count} weken',
+          ),
+      'onHrtForMonths' => ({required num count}) =>
+          (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+            count,
+            one: 'Aan HRT voor 1 maand',
+            other: 'Aan HRT voor ${count} maanden',
+          ),
+      'onHrtForYears' => ({required num count}) =>
+          (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+            count,
+            one: 'Aan HRT voor 1 jaar',
+            other: 'Aan HRT voor ${count} jaar',
+          ),
       _ => null,
     };
   }

--- a/lib/services/hrt_widget_service.dart
+++ b/lib/services/hrt_widget_service.dart
@@ -1,5 +1,6 @@
 import 'package:home_widget/home_widget.dart';
 import 'package:mona/data/providers/medication_intake_provider.dart';
+import 'package:mona/i18n/helpers/hrt_duration_l10n.dart';
 import 'package:mona/i18n/translations.g.dart';
 import 'package:mona/services/preferences_service.dart';
 import 'package:mona/services/widget_provider_names.dart';
@@ -41,7 +42,7 @@ class HrtWidgetService {
     final intakeCount = medicationIntakeProvider.takenIntakes.length;
 
     final title =
-        firstDate == null ? null : _durationText(hrtDurationSince(firstDate));
+        firstDate == null ? null : hrtDurationSince(firstDate).localizedText;
     final subtitle =
         firstDate == null ? null : t.intakesLoggedCount(count: intakeCount);
 
@@ -50,11 +51,4 @@ class HrtWidgetService {
     await HomeWidget.updateWidget(
         qualifiedAndroidName: WidgetProviderNames.hrtWidget);
   }
-
-  String _durationText(HrtDuration d) => switch (d.unit) {
-        HrtDurationUnit.days => t.onHrtForDays(count: d.value),
-        HrtDurationUnit.weeks => t.onHrtForWeeks(count: d.value),
-        HrtDurationUnit.months => t.onHrtForMonths(count: d.value),
-        HrtDurationUnit.years => t.onHrtForYears(count: d.value),
-      };
 }

--- a/lib/services/hrt_widget_service.dart
+++ b/lib/services/hrt_widget_service.dart
@@ -1,0 +1,59 @@
+import 'package:home_widget/home_widget.dart';
+import 'package:mona/data/providers/medication_intake_provider.dart';
+import 'package:mona/i18n/translations.g.dart';
+import 'package:mona/services/preferences_service.dart';
+import 'package:mona/util/hrt_duration.dart';
+
+/// Keeps the Android home screen widget in sync with the current
+/// "on HRT for X" duration and logged intake count.
+///
+/// Mirrors the same data [IntakeCounterCard] shows on the Intakes page,
+/// but pre-renders the localized strings on the Dart side so the native
+/// widget provider only has to display plain text (no duplicated
+/// pluralization / i18n logic on the Kotlin side).
+class HrtWidgetService {
+  static const String _androidWidgetName = 'HrtWidgetProvider';
+
+  static const String titleKey = 'hrt_widget_title';
+  static const String subtitleKey = 'hrt_widget_subtitle';
+  static const String enabledKey = 'hrt_widget_enabled';
+
+  final MedicationIntakeProvider medicationIntakeProvider;
+  final PreferencesService preferencesService;
+
+  HrtWidgetService({
+    required this.medicationIntakeProvider,
+    required this.preferencesService,
+  });
+
+  /// Recomputes the widget text and pushes it to the native side.
+  /// Call this whenever intakes or the relevant preference change.
+  Future<void> sync() async {
+    final enabled = preferencesService.intakeCounterEnabled;
+    await HomeWidget.saveWidgetData<bool>(enabledKey, enabled);
+
+    if (!enabled) {
+      await HomeWidget.updateWidget(androidName: _androidWidgetName);
+      return;
+    }
+
+    final firstDate = medicationIntakeProvider.firstTakenLocalDate;
+    final intakeCount = medicationIntakeProvider.takenIntakes.length;
+
+    final title =
+        firstDate == null ? null : _durationText(hrtDurationSince(firstDate));
+    final subtitle =
+        firstDate == null ? null : t.intakesLoggedCount(count: intakeCount);
+
+    await HomeWidget.saveWidgetData<String?>(titleKey, title);
+    await HomeWidget.saveWidgetData<String?>(subtitleKey, subtitle);
+    await HomeWidget.updateWidget(androidName: _androidWidgetName);
+  }
+
+  String _durationText(HrtDuration d) => switch (d.unit) {
+        HrtDurationUnit.days => t.onHrtForDays(count: d.value),
+        HrtDurationUnit.weeks => t.onHrtForWeeks(count: d.value),
+        HrtDurationUnit.months => t.onHrtForMonths(count: d.value),
+        HrtDurationUnit.years => t.onHrtForYears(count: d.value),
+      };
+}

--- a/lib/services/hrt_widget_service.dart
+++ b/lib/services/hrt_widget_service.dart
@@ -2,6 +2,7 @@ import 'package:home_widget/home_widget.dart';
 import 'package:mona/data/providers/medication_intake_provider.dart';
 import 'package:mona/i18n/translations.g.dart';
 import 'package:mona/services/preferences_service.dart';
+import 'package:mona/services/widget_provider_names.dart';
 import 'package:mona/util/hrt_duration.dart';
 
 /// Keeps the Android home screen widget in sync with the current
@@ -12,8 +13,6 @@ import 'package:mona/util/hrt_duration.dart';
 /// widget provider only has to display plain text (no duplicated
 /// pluralization / i18n logic on the Kotlin side).
 class HrtWidgetService {
-  static const String _androidWidgetName = 'HrtWidgetProvider';
-
   static const String titleKey = 'hrt_widget_title';
   static const String subtitleKey = 'hrt_widget_subtitle';
   static const String enabledKey = 'hrt_widget_enabled';
@@ -33,7 +32,8 @@ class HrtWidgetService {
     await HomeWidget.saveWidgetData<bool>(enabledKey, enabled);
 
     if (!enabled) {
-      await HomeWidget.updateWidget(androidName: _androidWidgetName);
+      await HomeWidget.updateWidget(
+          qualifiedAndroidName: WidgetProviderNames.hrtWidget);
       return;
     }
 
@@ -47,7 +47,8 @@ class HrtWidgetService {
 
     await HomeWidget.saveWidgetData<String?>(titleKey, title);
     await HomeWidget.saveWidgetData<String?>(subtitleKey, subtitle);
-    await HomeWidget.updateWidget(androidName: _androidWidgetName);
+    await HomeWidget.updateWidget(
+        qualifiedAndroidName: WidgetProviderNames.hrtWidget);
   }
 
   String _durationText(HrtDuration d) => switch (d.unit) {

--- a/lib/services/next_dose_widget_service.dart
+++ b/lib/services/next_dose_widget_service.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:home_widget/home_widget.dart';
+import 'package:intl/intl.dart';
+import 'package:mona/controllers/slots_builder.dart';
+import 'package:mona/data/model/date.dart';
+import 'package:mona/data/model/intake_slot.dart';
+import 'package:mona/data/model/scheduling_strategy.dart';
+import 'package:mona/data/providers/medication_intake_provider.dart';
+import 'package:mona/data/providers/medication_schedule_provider.dart';
+import 'package:mona/i18n/build_context_extensions.dart';
+import 'package:mona/i18n/helpers/administration_route_l10n.dart';
+import 'package:mona/i18n/helpers/molecule_l10n.dart';
+import 'package:mona/i18n/translations.g.dart';
+
+/// Keeps the Android "Next dose" home screen widget in sync with whichever
+/// schedule is next due (or overdue).
+///
+/// Picks the single most urgent not-yet-taken [IntakeSlot] using the same
+/// [SlotsBuilder] the home page uses, then pre-renders localized strings on
+/// the Dart side so the native widget provider only has to display plain
+/// text, mirroring [HrtWidgetService]'s split of responsibilities.
+class NextDoseWidgetService {
+  static const String _androidWidgetName = 'NextDoseWidgetProvider';
+
+  static const String titleKey = 'next_dose_widget_title';
+  static const String subtitleKey = 'next_dose_widget_subtitle';
+  static const String overdueKey = 'next_dose_widget_overdue';
+
+  final MedicationIntakeProvider medicationIntakeProvider;
+  final MedicationScheduleProvider medicationScheduleProvider;
+
+  NextDoseWidgetService({
+    required this.medicationIntakeProvider,
+    required this.medicationScheduleProvider,
+  });
+
+  /// Recomputes the widget text and pushes it to the native side.
+  /// Call this whenever schedules or intakes change.
+  Future<void> sync() async {
+    if (medicationScheduleProvider.schedules.isEmpty) {
+      await _push(title: t.empty_home, subtitle: null, overdue: false);
+      return;
+    }
+
+    final slots = SlotsBuilder(
+      medicationIntakeProvider,
+      medicationScheduleProvider,
+    ).intakeSlots();
+    final next = _pickNext(slots);
+
+    if (next == null) {
+      await _push(title: t.allDone, subtitle: t.noIntakesDue, overdue: false);
+      return;
+    }
+
+    final overdue = next.status == ScheduleStatus.overdue ||
+        next.status == ScheduleStatus.todayOverdue;
+
+    await _push(
+      title: next.schedule.name,
+      subtitle: '${_timingLabel(next)} • ${_detailText(next)}',
+      overdue: overdue,
+    );
+  }
+
+  Future<void> _push({
+    required String title,
+    required String? subtitle,
+    required bool overdue,
+  }) async {
+    await HomeWidget.saveWidgetData<String>(titleKey, title);
+    await HomeWidget.saveWidgetData<String?>(subtitleKey, subtitle);
+    await HomeWidget.saveWidgetData<bool>(overdueKey, overdue);
+    await HomeWidget.updateWidget(androidName: _androidWidgetName);
+  }
+
+  /// Picks the single most urgent slot that hasn't been taken yet:
+  /// overdue first (oldest miss first), then today, then the soonest
+  /// upcoming occurrence. Returns null when every schedule is caught up.
+  IntakeSlot? _pickNext(List<IntakeSlot> slots) {
+    final pending =
+        slots.where((s) => s.status != ScheduleStatus.taken).toList()
+          ..sort(_compareUrgency);
+    return pending.isEmpty ? null : pending.first;
+  }
+
+  int _compareUrgency(IntakeSlot a, IntakeSlot b) {
+    final rankCompare = _rank(a.status).compareTo(_rank(b.status));
+    if (rankCompare != 0) return rankCompare;
+
+    if (a.date != b.date) {
+      return a.date.isBefore(b.date) ? -1 : 1;
+    }
+
+    final at = a.time;
+    final bt = b.time;
+    if (at == null && bt == null) return 0;
+    if (at == null) return -1;
+    if (bt == null) return 1;
+    final hourCompare = at.hour.compareTo(bt.hour);
+    return hourCompare != 0 ? hourCompare : at.minute.compareTo(bt.minute);
+  }
+
+  int _rank(ScheduleStatus status) => switch (status) {
+        ScheduleStatus.overdue || ScheduleStatus.todayOverdue => 0,
+        ScheduleStatus.todayEarly || ScheduleStatus.today => 1,
+        ScheduleStatus.upcoming => 2,
+        ScheduleStatus.taken => 3,
+      };
+
+  String _timingLabel(IntakeSlot slot) {
+    switch (slot.status) {
+      case ScheduleStatus.overdue:
+      case ScheduleStatus.todayOverdue:
+        return t.nextDoseOverdueLabel;
+      case ScheduleStatus.todayEarly:
+      case ScheduleStatus.today:
+        final time = slot.time;
+        return time == null ? t.nextDoseDueTodayLabel : _formatTime(time);
+      case ScheduleStatus.upcoming:
+        return _upcomingLabel(slot.date);
+      case ScheduleStatus.taken:
+        return '';
+    }
+  }
+
+  String _upcomingLabel(Date date) {
+    final diff = date.daysAwayFromToday;
+    if (diff == 1) {
+      final tomorrow = t.tomorrow;
+      return tomorrow[0].toUpperCase() + tomorrow.substring(1);
+    }
+    return t.inDaysCount(count: diff);
+  }
+
+  String _formatTime(TimeOfDay time) {
+    final dt = DateTime(2000, 1, 1, time.hour, time.minute);
+    return DateFormat.jm(_languageTag).format(dt);
+  }
+
+  String _detailText(IntakeSlot slot) {
+    final schedule = slot.schedule;
+    return '${schedule.dose} ${schedule.molecule.localizedUnit} • '
+        '${schedule.molecule.localizedNameWithEster(schedule.ester)} • '
+        '${schedule.administrationRoute.localizedName}';
+  }
+
+  String get _languageTag =>
+      intlSafeLanguageTag(LocaleSettings.currentLocale.languageTag);
+}

--- a/lib/services/next_dose_widget_service.dart
+++ b/lib/services/next_dose_widget_service.dart
@@ -11,6 +11,7 @@ import 'package:mona/i18n/build_context_extensions.dart';
 import 'package:mona/i18n/helpers/administration_route_l10n.dart';
 import 'package:mona/i18n/helpers/molecule_l10n.dart';
 import 'package:mona/i18n/translations.g.dart';
+import 'package:mona/services/widget_provider_names.dart';
 
 /// Keeps the Android "Next dose" home screen widget in sync with whichever
 /// schedule is next due (or overdue).
@@ -20,8 +21,6 @@ import 'package:mona/i18n/translations.g.dart';
 /// the Dart side so the native widget provider only has to display plain
 /// text, mirroring [HrtWidgetService]'s split of responsibilities.
 class NextDoseWidgetService {
-  static const String _androidWidgetName = 'NextDoseWidgetProvider';
-
   static const String titleKey = 'next_dose_widget_title';
   static const String subtitleKey = 'next_dose_widget_subtitle';
   static const String overdueKey = 'next_dose_widget_overdue';
@@ -71,7 +70,8 @@ class NextDoseWidgetService {
     await HomeWidget.saveWidgetData<String>(titleKey, title);
     await HomeWidget.saveWidgetData<String?>(subtitleKey, subtitle);
     await HomeWidget.saveWidgetData<bool>(overdueKey, overdue);
-    await HomeWidget.updateWidget(androidName: _androidWidgetName);
+    await HomeWidget.updateWidget(
+        qualifiedAndroidName: WidgetProviderNames.nextDoseWidget);
   }
 
   /// Picks the single most urgent slot that hasn't been taken yet:

--- a/lib/services/next_dose_widget_service.dart
+++ b/lib/services/next_dose_widget_service.dart
@@ -1,13 +1,8 @@
-import 'package:flutter/material.dart';
 import 'package:home_widget/home_widget.dart';
-import 'package:intl/intl.dart';
-import 'package:mona/controllers/slots_builder.dart';
-import 'package:mona/data/model/date.dart';
+import 'package:mona/controllers/next_dose_resolver.dart';
 import 'package:mona/data/model/intake_slot.dart';
-import 'package:mona/data/model/scheduling_strategy.dart';
 import 'package:mona/data/providers/medication_intake_provider.dart';
 import 'package:mona/data/providers/medication_schedule_provider.dart';
-import 'package:mona/i18n/build_context_extensions.dart';
 import 'package:mona/i18n/helpers/administration_route_l10n.dart';
 import 'package:mona/i18n/helpers/molecule_l10n.dart';
 import 'package:mona/i18n/translations.g.dart';
@@ -16,10 +11,11 @@ import 'package:mona/services/widget_provider_names.dart';
 /// Keeps the Android "Next dose" home screen widget in sync with whichever
 /// schedule is next due (or overdue).
 ///
-/// Picks the single most urgent not-yet-taken [IntakeSlot] using the same
-/// [SlotsBuilder] the home page uses, then pre-renders localized strings on
-/// the Dart side so the native widget provider only has to display plain
-/// text, mirroring [HrtWidgetService]'s split of responsibilities.
+/// Picks the single most urgent not-yet-taken [IntakeSlot] via
+/// [NextDoseResolver] (same one [StatusWidgetService] uses), then
+/// pre-renders localized strings on the Dart side so the native widget
+/// provider only has to display plain text, mirroring [HrtWidgetService]'s
+/// split of responsibilities.
 class NextDoseWidgetService {
   static const String titleKey = 'next_dose_widget_title';
   static const String subtitleKey = 'next_dose_widget_subtitle';
@@ -27,11 +23,13 @@ class NextDoseWidgetService {
 
   final MedicationIntakeProvider medicationIntakeProvider;
   final MedicationScheduleProvider medicationScheduleProvider;
+  final NextDoseResolver _resolver;
 
   NextDoseWidgetService({
     required this.medicationIntakeProvider,
     required this.medicationScheduleProvider,
-  });
+    NextDoseResolver resolver = const NextDoseResolver(),
+  }) : _resolver = resolver;
 
   /// Recomputes the widget text and pushes it to the native side.
   /// Call this whenever schedules or intakes change.
@@ -41,24 +39,20 @@ class NextDoseWidgetService {
       return;
     }
 
-    final slots = SlotsBuilder(
+    final next = _resolver.pickNext(
       medicationIntakeProvider,
       medicationScheduleProvider,
-    ).intakeSlots();
-    final next = _pickNext(slots);
+    );
 
     if (next == null) {
       await _push(title: t.allDone, subtitle: t.noIntakesDue, overdue: false);
       return;
     }
 
-    final overdue = next.status == ScheduleStatus.overdue ||
-        next.status == ScheduleStatus.todayOverdue;
-
     await _push(
       title: next.schedule.name,
-      subtitle: '${_timingLabel(next)} • ${_detailText(next)}',
-      overdue: overdue,
+      subtitle: '${_resolver.timingLabel(next)} • ${_detailText(next)}',
+      overdue: _resolver.isOverdue(next),
     );
   }
 
@@ -74,77 +68,10 @@ class NextDoseWidgetService {
         qualifiedAndroidName: WidgetProviderNames.nextDoseWidget);
   }
 
-  /// Picks the single most urgent slot that hasn't been taken yet:
-  /// overdue first (oldest miss first), then today, then the soonest
-  /// upcoming occurrence. Returns null when every schedule is caught up.
-  IntakeSlot? _pickNext(List<IntakeSlot> slots) {
-    final pending =
-        slots.where((s) => s.status != ScheduleStatus.taken).toList()
-          ..sort(_compareUrgency);
-    return pending.isEmpty ? null : pending.first;
-  }
-
-  int _compareUrgency(IntakeSlot a, IntakeSlot b) {
-    final rankCompare = _rank(a.status).compareTo(_rank(b.status));
-    if (rankCompare != 0) return rankCompare;
-
-    if (a.date != b.date) {
-      return a.date.isBefore(b.date) ? -1 : 1;
-    }
-
-    final at = a.time;
-    final bt = b.time;
-    if (at == null && bt == null) return 0;
-    if (at == null) return -1;
-    if (bt == null) return 1;
-    final hourCompare = at.hour.compareTo(bt.hour);
-    return hourCompare != 0 ? hourCompare : at.minute.compareTo(bt.minute);
-  }
-
-  int _rank(ScheduleStatus status) => switch (status) {
-        ScheduleStatus.overdue || ScheduleStatus.todayOverdue => 0,
-        ScheduleStatus.todayEarly || ScheduleStatus.today => 1,
-        ScheduleStatus.upcoming => 2,
-        ScheduleStatus.taken => 3,
-      };
-
-  String _timingLabel(IntakeSlot slot) {
-    switch (slot.status) {
-      case ScheduleStatus.overdue:
-      case ScheduleStatus.todayOverdue:
-        return t.nextDoseOverdueLabel;
-      case ScheduleStatus.todayEarly:
-      case ScheduleStatus.today:
-        final time = slot.time;
-        return time == null ? t.nextDoseDueTodayLabel : _formatTime(time);
-      case ScheduleStatus.upcoming:
-        return _upcomingLabel(slot.date);
-      case ScheduleStatus.taken:
-        return '';
-    }
-  }
-
-  String _upcomingLabel(Date date) {
-    final diff = date.daysAwayFromToday;
-    if (diff == 1) {
-      final tomorrow = t.tomorrow;
-      return tomorrow[0].toUpperCase() + tomorrow.substring(1);
-    }
-    return t.inDaysCount(count: diff);
-  }
-
-  String _formatTime(TimeOfDay time) {
-    final dt = DateTime(2000, 1, 1, time.hour, time.minute);
-    return DateFormat.jm(_languageTag).format(dt);
-  }
-
   String _detailText(IntakeSlot slot) {
     final schedule = slot.schedule;
     return '${schedule.dose} ${schedule.molecule.localizedUnit} • '
         '${schedule.molecule.localizedNameWithEster(schedule.ester)} • '
         '${schedule.administrationRoute.localizedName}';
   }
-
-  String get _languageTag =>
-      intlSafeLanguageTag(LocaleSettings.currentLocale.languageTag);
 }

--- a/lib/services/recent_intakes_widget_service.dart
+++ b/lib/services/recent_intakes_widget_service.dart
@@ -4,6 +4,7 @@ import 'package:mona/data/providers/medication_intake_provider.dart';
 import 'package:mona/i18n/build_context_extensions.dart';
 import 'package:mona/i18n/helpers/medication_intake_l10n.dart';
 import 'package:mona/i18n/translations.g.dart';
+import 'package:mona/services/widget_provider_names.dart';
 
 /// Keeps the Android "Recent injections" home screen widget in sync with the
 /// most recently taken intakes.
@@ -16,7 +17,6 @@ import 'package:mona/i18n/translations.g.dart';
 /// The widget shows a fixed number of rows (no native scrolling), so only
 /// the [rowCount] most recent intakes are pushed.
 class RecentIntakesWidgetService {
-  static const String _androidWidgetName = 'RecentIntakesWidgetProvider';
   static const int rowCount = 4;
 
   static const String countKey = 'recent_intakes_widget_count';
@@ -52,7 +52,8 @@ class RecentIntakesWidgetService {
     // when count is 0 (see RecentIntakesWidgetProvider), same fallback
     // pattern as HrtWidgetService.
     await HomeWidget.saveWidgetData<int>(countKey, count);
-    await HomeWidget.updateWidget(androidName: _androidWidgetName);
+    await HomeWidget.updateWidget(
+        qualifiedAndroidName: WidgetProviderNames.recentIntakesWidget);
   }
 
   String get _languageTag =>

--- a/lib/services/recent_intakes_widget_service.dart
+++ b/lib/services/recent_intakes_widget_service.dart
@@ -22,8 +22,7 @@ class RecentIntakesWidgetService {
   static const String countKey = 'recent_intakes_widget_count';
 
   static String dateKey(int index) => 'recent_intakes_widget_date_$index';
-  static String summaryKey(int index) =>
-      'recent_intakes_widget_summary_$index';
+  static String summaryKey(int index) => 'recent_intakes_widget_summary_$index';
 
   final MedicationIntakeProvider medicationIntakeProvider;
 

--- a/lib/services/recent_intakes_widget_service.dart
+++ b/lib/services/recent_intakes_widget_service.dart
@@ -1,0 +1,60 @@
+import 'package:home_widget/home_widget.dart';
+import 'package:intl/intl.dart';
+import 'package:mona/data/providers/medication_intake_provider.dart';
+import 'package:mona/i18n/build_context_extensions.dart';
+import 'package:mona/i18n/helpers/medication_intake_l10n.dart';
+import 'package:mona/i18n/translations.g.dart';
+
+/// Keeps the Android "Recent injections" home screen widget in sync with the
+/// most recently taken intakes.
+///
+/// Mirrors the top of the Intakes page's list (date + [localizedSummary] per
+/// row), pre-rendered on the Dart side so the native widget provider only
+/// has to display plain text rows, same split of responsibilities as
+/// [HrtWidgetService] and [NextDoseWidgetService].
+///
+/// The widget shows a fixed number of rows (no native scrolling), so only
+/// the [rowCount] most recent intakes are pushed.
+class RecentIntakesWidgetService {
+  static const String _androidWidgetName = 'RecentIntakesWidgetProvider';
+  static const int rowCount = 4;
+
+  static const String countKey = 'recent_intakes_widget_count';
+
+  static String dateKey(int index) => 'recent_intakes_widget_date_$index';
+  static String summaryKey(int index) =>
+      'recent_intakes_widget_summary_$index';
+
+  final MedicationIntakeProvider medicationIntakeProvider;
+
+  RecentIntakesWidgetService({required this.medicationIntakeProvider});
+
+  /// Recomputes the widget rows and pushes them to the native side.
+  /// Call this whenever intakes change.
+  Future<void> sync() async {
+    final intakes =
+        medicationIntakeProvider.takenIntakesSortedDesc.take(rowCount);
+
+    var count = 0;
+    for (final intake in intakes) {
+      await HomeWidget.saveWidgetData<String>(
+        dateKey(count),
+        DateFormat.yMMMd(_languageTag).format(intake.takenLocalDateTime!),
+      );
+      await HomeWidget.saveWidgetData<String>(
+        summaryKey(count),
+        intake.localizedSummary,
+      );
+      count++;
+    }
+
+    // Kotlin falls back to a localized "no intakes yet" placeholder row
+    // when count is 0 (see RecentIntakesWidgetProvider), same fallback
+    // pattern as HrtWidgetService.
+    await HomeWidget.saveWidgetData<int>(countKey, count);
+    await HomeWidget.updateWidget(androidName: _androidWidgetName);
+  }
+
+  String get _languageTag =>
+      intlSafeLanguageTag(LocaleSettings.currentLocale.languageTag);
+}

--- a/lib/services/status_widget_service.dart
+++ b/lib/services/status_widget_service.dart
@@ -1,0 +1,107 @@
+import 'package:collection/collection.dart';
+import 'package:home_widget/home_widget.dart';
+import 'package:mona/controllers/next_dose_resolver.dart';
+import 'package:mona/data/model/generic_supply_item.dart';
+import 'package:mona/data/model/medication_supply_item.dart';
+import 'package:mona/data/providers/medication_intake_provider.dart';
+import 'package:mona/data/providers/medication_schedule_provider.dart';
+import 'package:mona/data/providers/supply_item_provider.dart';
+import 'package:mona/i18n/helpers/generic_type_l10n.dart';
+import 'package:mona/i18n/helpers/hrt_duration_l10n.dart';
+import 'package:mona/i18n/translations.g.dart';
+import 'package:mona/services/widget_provider_names.dart';
+import 'package:mona/util/hrt_duration.dart';
+
+/// Keeps the Android "Status" home screen widget (a square dashboard: HRT
+/// duration, next dose, and the most urgent supply) in sync.
+///
+/// Reuses [NextDoseResolver] for the next-dose row (same logic
+/// [NextDoseWidgetService] uses) and [SupplyItemProvider]'s existing
+/// ratio-ordering for the supply row, so this is purely a compact rollup of
+/// state the other widgets already compute -- no new domain logic.
+class StatusWidgetService {
+  static const String durationKey = 'status_widget_duration';
+  static const String nextDoseKey = 'status_widget_next_dose';
+  static const String nextDoseOverdueKey = 'status_widget_next_dose_overdue';
+  static const String supplyKey = 'status_widget_supply';
+  static const String supplyLowKey = 'status_widget_supply_low';
+
+  /// Below this remaining fraction, a medication supply's row is flagged low.
+  static const double _lowMedicationRatio = 0.2;
+
+  /// At or below this raw count, a generic supply's row is flagged low.
+  static const int _lowGenericAmount = 2;
+
+  final MedicationIntakeProvider medicationIntakeProvider;
+  final MedicationScheduleProvider medicationScheduleProvider;
+  final SupplyItemProvider supplyItemProvider;
+  final NextDoseResolver _resolver;
+
+  StatusWidgetService({
+    required this.medicationIntakeProvider,
+    required this.medicationScheduleProvider,
+    required this.supplyItemProvider,
+    NextDoseResolver resolver = const NextDoseResolver(),
+  }) : _resolver = resolver;
+
+  /// Recomputes the widget text and pushes it to the native side.
+  /// Call this whenever intakes, schedules, or supplies change.
+  Future<void> sync() async {
+    await HomeWidget.saveWidgetData<String>(durationKey, _durationText());
+
+    final next = medicationScheduleProvider.schedules.isEmpty
+        ? null
+        : _resolver.pickNext(
+            medicationIntakeProvider, medicationScheduleProvider);
+    await HomeWidget.saveWidgetData<String>(
+      nextDoseKey,
+      next == null
+          ? t.allDone
+          : '${next.schedule.name} • '
+              '${_resolver.timingLabel(next)}',
+    );
+    await HomeWidget.saveWidgetData<bool>(
+      nextDoseOverdueKey,
+      next != null && _resolver.isOverdue(next),
+    );
+
+    final (supplyText, supplyLow) = _supplyStatus();
+    await HomeWidget.saveWidgetData<String>(supplyKey, supplyText);
+    await HomeWidget.saveWidgetData<bool>(supplyLowKey, supplyLow);
+
+    await HomeWidget.updateWidget(
+        qualifiedAndroidName: WidgetProviderNames.statusWidget);
+  }
+
+  String _durationText() {
+    final firstDate = medicationIntakeProvider.firstTakenLocalDate;
+    return firstDate == null
+        ? t.empty_home
+        : hrtDurationSince(firstDate).localizedText;
+  }
+
+  (String, bool) _supplyStatus() {
+    final MedicationSupplyItem? worstMedication =
+        supplyItemProvider.medicationItemsOrderedByRatio.firstOrNull;
+    if (worstMedication != null) {
+      final percent = (worstMedication.getRatio() * 100).round();
+      return (
+        '${worstMedication.name}: $percent%',
+        worstMedication.getRatio() < _lowMedicationRatio,
+      );
+    }
+
+    final genericItems = [...supplyItemProvider.genericItems]
+      ..sort((a, b) => a.amount.compareTo(b.amount));
+    final GenericSupply? worstGeneric = genericItems.firstOrNull;
+    if (worstGeneric != null) {
+      return (
+        '${worstGeneric.name}: '
+            '${worstGeneric.genericSupplyType.localizedRemaining(worstGeneric.amount)}',
+        worstGeneric.amount <= _lowGenericAmount,
+      );
+    }
+
+    return (t.empty_supplies, false);
+  }
+}

--- a/lib/services/supplies_widget_service.dart
+++ b/lib/services/supplies_widget_service.dart
@@ -1,0 +1,70 @@
+import 'package:home_widget/home_widget.dart';
+import 'package:mona/data/model/generic_supply_item.dart';
+import 'package:mona/data/model/medication_supply_item.dart';
+import 'package:mona/data/model/supply_item.dart';
+import 'package:mona/data/providers/supply_item_provider.dart';
+import 'package:mona/i18n/helpers/supply_item_l10n.dart';
+import 'package:mona/services/widget_provider_names.dart';
+
+/// Keeps the Android "Supplies" home screen widget in sync with the supply
+/// items running lowest, so you notice you're about to run out before you
+/// do.
+///
+/// Mirrors [RecentIntakesWidgetService]'s shape: fixed, non-scrolling rows
+/// pre-rendered on the Dart side. Medication supplies (which have a
+/// meaningful remaining-percentage) are ranked worst-ratio-first ahead of
+/// generic supplies (syringes, wipes, ...), since running out of the actual
+/// medication is the more critical failure mode.
+class SuppliesWidgetService {
+  static const int rowCount = 4;
+
+  static const String countKey = 'supplies_widget_count';
+
+  /// Below this remaining fraction, a medication supply's row is flagged low.
+  static const double _lowMedicationRatio = 0.2;
+
+  /// At or below this raw count, a generic supply's row is flagged low.
+  static const int _lowGenericAmount = 2;
+
+  static String nameKey(int index) => 'supplies_widget_name_$index';
+  static String summaryKey(int index) => 'supplies_widget_summary_$index';
+  static String lowKey(int index) => 'supplies_widget_low_$index';
+
+  final SupplyItemProvider supplyItemProvider;
+
+  SuppliesWidgetService({required this.supplyItemProvider});
+
+  /// Recomputes the widget rows and pushes them to the native side.
+  /// Call this whenever supplies change.
+  Future<void> sync() async {
+    final items = _orderedByUrgency().take(rowCount);
+
+    var count = 0;
+    for (final item in items) {
+      await HomeWidget.saveWidgetData<String>(nameKey(count), item.name);
+      await HomeWidget.saveWidgetData<String>(
+          summaryKey(count), item.localizedSummary);
+      await HomeWidget.saveWidgetData<bool>(lowKey(count), _isLow(item));
+      count++;
+    }
+
+    await HomeWidget.saveWidgetData<int>(countKey, count);
+    await HomeWidget.updateWidget(
+        qualifiedAndroidName: WidgetProviderNames.suppliesWidget);
+  }
+
+  List<SupplyItem> _orderedByUrgency() {
+    final generic = [...supplyItemProvider.genericItems]
+      ..sort((a, b) => a.amount.compareTo(b.amount));
+    return [
+      ...supplyItemProvider.medicationItemsOrderedByRatio,
+      ...generic,
+    ];
+  }
+
+  bool _isLow(SupplyItem item) => switch (item) {
+        final MedicationSupplyItem m => m.getRatio() < _lowMedicationRatio,
+        final GenericSupply g => g.amount <= _lowGenericAmount,
+        _ => false,
+      };
+}

--- a/lib/services/widget_provider_names.dart
+++ b/lib/services/widget_provider_names.dart
@@ -1,0 +1,25 @@
+/// Fully-qualified class names for the Android AppWidgetProviders, for use
+/// with [HomeWidget.updateWidget]'s `qualifiedAndroidName` parameter.
+///
+/// home_widget's `androidName` parameter instead resolves classes as
+/// `context.packageName + "." + androidName` -- but `context.packageName`
+/// is the applicationId, which varies by build type (debug builds append
+/// `.dev`, see android/app/build.gradle's applicationIdSuffix), while these
+/// classes live in the stable `namespace` from build.gradle. Using
+/// `androidName` there throws ClassNotFoundException on debug builds, so
+/// `qualifiedAndroidName` with the namespace hardcoded here is the one that
+/// actually works across build types.
+abstract final class WidgetProviderNames {
+  static const String _package = 'com.deliacheminot.mona';
+
+  static const String hrtWidget = '$_package.HrtWidgetProvider';
+  static const String nextDoseWidget = '$_package.NextDoseWidgetProvider';
+  static const String recentIntakesWidget =
+      '$_package.RecentIntakesWidgetProvider';
+
+  static const List<String> all = [
+    hrtWidget,
+    nextDoseWidget,
+    recentIntakesWidget,
+  ];
+}

--- a/lib/services/widget_provider_names.dart
+++ b/lib/services/widget_provider_names.dart
@@ -16,10 +16,14 @@ abstract final class WidgetProviderNames {
   static const String nextDoseWidget = '$_package.NextDoseWidgetProvider';
   static const String recentIntakesWidget =
       '$_package.RecentIntakesWidgetProvider';
+  static const String statusWidget = '$_package.StatusWidgetProvider';
+  static const String suppliesWidget = '$_package.SuppliesWidgetProvider';
 
   static const List<String> all = [
     hrtWidget,
     nextDoseWidget,
     recentIntakesWidget,
+    statusWidget,
+    suppliesWidget,
   ];
 }

--- a/lib/services/widget_theme_service.dart
+++ b/lib/services/widget_theme_service.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:home_widget/home_widget.dart';
+import 'package:mona/services/widget_provider_names.dart';
+
+/// Keeps the Android home screen widgets' colors in sync with the app's
+/// *actual* current [ColorScheme] -- Material You dynamic color, a custom
+/// theme, or the default palette, whichever is active -- instead of a fixed
+/// color baked into the widgets.
+///
+/// Pushes both the light and dark variant of each role home_widget stores;
+/// the native side (see WidgetColors.kt) picks whichever matches the
+/// device's current night mode when it renders. Called from [MonaApp]'s
+/// build method, right where the app resolves its own theme, so this is
+/// always in step with what's on screen.
+class WidgetThemeService {
+  Future<void> sync({
+    required ColorScheme light,
+    required ColorScheme dark,
+  }) async {
+    await _pushScheme('light', light);
+    await _pushScheme('dark', dark);
+    for (final name in WidgetProviderNames.all) {
+      await HomeWidget.updateWidget(qualifiedAndroidName: name);
+    }
+  }
+
+  Future<void> _pushScheme(String suffix, ColorScheme scheme) async {
+    await _save('widget_card_background_$suffix', scheme.surfaceContainer);
+    await _save('widget_icon_background_$suffix', scheme.tertiaryContainer);
+    await _save('widget_icon_foreground_$suffix', scheme.onTertiaryContainer);
+    await _save('widget_title_text_$suffix', scheme.onSurface);
+    await _save('widget_subtitle_text_$suffix', scheme.onSurfaceVariant);
+    await _save(
+        'widget_overdue_icon_background_$suffix', scheme.errorContainer);
+    await _save(
+        'widget_overdue_icon_foreground_$suffix', scheme.onErrorContainer);
+  }
+
+  Future<void> _save(String key, Color color) =>
+      HomeWidget.saveWidgetData<int>(key, color.toARGB32());
+}

--- a/lib/ui/views/intakes/intake_counter_card.dart
+++ b/lib/ui/views/intakes/intake_counter_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:m3e_core/m3e_core.dart';
 import 'package:material_symbols_icons/symbols.dart';
+import 'package:mona/i18n/helpers/hrt_duration_l10n.dart';
 import 'package:mona/i18n/translations.g.dart';
 import 'package:mona/util/hrt_duration.dart';
 
@@ -33,18 +34,11 @@ class IntakeCounterCard extends StatelessWidget {
               color: theme.colorScheme.onTertiaryContainer,
             ),
           ),
-          title: Text(_durationText(duration!),
-              style: theme.textTheme.titleMedium),
+          title:
+              Text(duration!.localizedText, style: theme.textTheme.titleMedium),
           subtitle: Text(t.intakesLoggedCount(count: intakeCount)),
         ),
       ],
     );
   }
-
-  String _durationText(HrtDuration d) => switch (d.unit) {
-        HrtDurationUnit.days => t.onHrtForDays(count: d.value),
-        HrtDurationUnit.weeks => t.onHrtForWeeks(count: d.value),
-        HrtDurationUnit.months => t.onHrtForMonths(count: d.value),
-        HrtDurationUnit.years => t.onHrtForYears(count: d.value),
-      };
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -496,6 +496,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  home_widget:
+    dependency: "direct main"
+    description:
+      name: home_widget
+      sha256: "7430f7549d42cef2e729bd3c779de748b93f1eb78b1abfe6bca8fffd1cfce3e9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.0+1"
   hooks:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,7 @@ dependencies:
   collection: ^1.19.1
   http: ^1.2.0
   package_info_plus: ^9.0.0
+  home_widget: ^0.7.0
   url_launcher: ^6.2.6
   path_provider: ^2.1.4
   open_filex: ^4.5.0


### PR DESCRIPTION
### Description

Added 5 home screen widgets for android, all built the same way: dart does all the work (date/i18n/domain logic already exists in the app) and pushes the text to home_widget, kotlin side just renders it with RemoteViews, no logic duplicated natively.

- HRT progress: on hrt for x days + intake count (same as the IntakeCounterCard)
- Next dose: whichever schedule is next due or overdue, same ranking the home page uses (overdue first, then today, then soonest upcoming)
- Recent injections: last 4 taken intakes
- Status: small square widget, hrt duration + next dose + worst supply all in one
- Supplies: shows whatever supply item is running lowest so you notice before you run out

They all pick up the app's actual current theme (dynamic color, custom theme, whatever's active, light and dark) instead of a fixed color, and the text auto sizes when you resize the widget (android 12+, falls back to a fixed size on older versions).

Also fixed 2 bugs in home_widget along the way. updateWidget's androidName param uses context.packageName to find the provider class, which breaks on debug builds because of the .dev suffix, so widgets only ever actually updated when you removed and re added them, not when the app pushed new data. switched to qualifiedAndroidName instead. and colors weren't syncing at all because synced ints need to be read back as Long not Int, dart ints over 2^31 get sent as Int64 over the platform channel and every opaque color is one of those.

Related to issue(s): 102

### Type of change

- New feature (non-breaking change which adds functionality)
- Bug fix (non-breaking change which fixes an issue)

### Screenshots (if appropriate):

<img width="1080" height="1483" alt="image" src="https://github.com/user-attachments/assets/80394ba6-1157-4108-bb68-f93af14e4a30" />
<img width="1080" height="879" alt="image" src="https://github.com/user-attachments/assets/5b1b9f24-e799-474c-88e4-e48555cab229" />

