### PR TITLE
feat: add a Take action and snooze button to medication reminder notifications

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -39,6 +39,11 @@
         <receiver
             android:exported="false"
             android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver" />
+        <!-- Required by flutter_local_notifications to process notification actions
+             (e.g. the "Take" action, see notification_action_handler.dart) -->
+        <receiver
+            android:exported="false"
+            android:name="com.dexterous.flutterlocalnotifications.ActionBroadcastReceiver" />
         <receiver
             android:exported="false"
             android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver">

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -9,6 +9,7 @@ import 'package:mona/distribution.dart';
 import 'package:mona/i18n/build_context_extensions.dart';
 import 'package:mona/i18n/locale_provider.dart';
 import 'package:mona/i18n/tok_localizations.dart';
+import 'package:mona/services/notification_action_handler.dart';
 import 'package:mona/services/notification_service.dart';
 import 'package:mona/services/preferences_service.dart';
 import 'package:mona/theme/app_theme_controller.dart';
@@ -36,7 +37,10 @@ class _MonaAppState extends State<MonaApp> with WidgetsBindingObserver {
     _lastTimeZone = DateTime.now().timeZoneOffset.toString();
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      await NotificationService().initialize();
+      await NotificationService().initialize(
+        onDidReceiveBackgroundNotificationResponse:
+            onBackgroundNotificationResponse,
+      );
       if (!mounted) return;
       _medicationScheduleProvider = context.read<MedicationScheduleProvider>();
       _medicationIntakeProvider = context.read<MedicationIntakeProvider>();
@@ -81,6 +85,10 @@ class _MonaAppState extends State<MonaApp> with WidgetsBindingObserver {
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.resumed) {
       _checkTimezoneChange();
+      // Picks up any intake logged by the "Take" notification action (see
+      // notification_action_handler.dart) while the app was backgrounded;
+      // its notifyListeners() also re-triggers _regenerateNotifications.
+      _medicationIntakeProvider.fetchIntakes();
     }
   }
 

--- a/lib/controllers/notification_scheduler.dart
+++ b/lib/controllers/notification_scheduler.dart
@@ -60,6 +60,7 @@ class NotificationScheduler {
         date: dateFormat.format(plan.dateTime),
       ),
       scheduledTime: plan.dateTime,
+      scheduleId: plan.schedule.id,
     );
   }
 
@@ -76,6 +77,9 @@ class NotificationScheduler {
         time: timeFormat.format(plan.firstFire),
       ),
       firstOccurrence: plan.firstFire,
+      scheduleId: plan.schedule.id,
+      scheduledTimeHour: plan.time.hour,
+      scheduledTimeMinute: plan.time.minute,
     );
   }
 
@@ -92,6 +96,9 @@ class NotificationScheduler {
         weekday: weekdayFormat.format(plan.firstFire),
       ),
       firstOccurrence: plan.firstFire,
+      scheduleId: plan.schedule.id,
+      scheduledTimeHour: plan.time.hour,
+      scheduledTimeMinute: plan.time.minute,
     );
   }
 }

--- a/lib/data/providers/medication_intake_provider.dart
+++ b/lib/data/providers/medication_intake_provider.dart
@@ -14,7 +14,7 @@ class MedicationIntakeProvider extends ChangeNotifier {
   final Repository<MedicationIntake> repository;
 
   MedicationIntakeProvider({Repository<MedicationIntake>? repository})
-      : repository = repository ?? _medicationIntakeRepository {
+      : repository = repository ?? defaultRepository {
     _init();
   }
 
@@ -165,7 +165,7 @@ class MedicationIntakeProvider extends ChangeNotifier {
         .reduce((a, b) => a.takenDateTime!.isAfter(b.takenDateTime!) ? a : b);
   }
 
-  static final _medicationIntakeRepository = Repository<MedicationIntake>(
+  static final defaultRepository = Repository<MedicationIntake>(
     tableName: 'medication_intakes',
     toMap: (MedicationIntake intake) => intake.toMap(),
     fromMap: (map) =>

--- a/lib/data/providers/medication_schedule_provider.dart
+++ b/lib/data/providers/medication_schedule_provider.dart
@@ -19,7 +19,7 @@ class MedicationScheduleProvider extends ChangeNotifier {
   }
 
   MedicationScheduleProvider({Repository<MedicationSchedule>? repository})
-      : repository = repository ?? _defaultRepository {
+      : repository = repository ?? defaultRepository {
     _init();
   }
 
@@ -54,7 +54,7 @@ class MedicationScheduleProvider extends ChangeNotifier {
     await fetchSchedules();
   }
 
-  static final _defaultRepository = Repository<MedicationSchedule>(
+  static final defaultRepository = Repository<MedicationSchedule>(
     tableName: 'medication_schedules',
     toMap: (MedicationSchedule schedule) => schedule.toMap(),
     fromMap: (map) =>

--- a/lib/i18n/en.i18next.json
+++ b/lib/i18n/en.i18next.json
@@ -92,6 +92,7 @@
   "notificationMedicationReminderBodyDate": "Scheduled for {{date}}",
   "notificationMedicationReminderBodyTime": "Scheduled for {{time}}",
   "notificationMedicationReminderBodyWeekday": "Scheduled for {{weekday}}",
+  "notificationActionTake": "Take",
   "addSchedule": "Add a schedule",
   "addScheduleToGetStarted": "Add a schedule to get started.",
   "newSchedule": "New schedule",

--- a/lib/i18n/en.i18next.json
+++ b/lib/i18n/en.i18next.json
@@ -93,6 +93,7 @@
   "notificationMedicationReminderBodyTime": "Scheduled for {{time}}",
   "notificationMedicationReminderBodyWeekday": "Scheduled for {{weekday}}",
   "notificationActionTake": "Take",
+  "notificationActionSnooze": "In {{minutes}}m",
   "addSchedule": "Add a schedule",
   "addScheduleToGetStarted": "Add a schedule to get started.",
   "newSchedule": "New schedule",

--- a/lib/i18n/translations.g.dart
+++ b/lib/i18n/translations.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 18
-/// Strings: 3575 (198 per locale)
+/// Strings: 3576 (198 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/translations.g.dart
+++ b/lib/i18n/translations.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 18
-/// Strings: 3462 (192 per locale)
+/// Strings: 3575 (198 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/translations_en.g.dart
+++ b/lib/i18n/translations_en.g.dart
@@ -316,6 +316,9 @@ class Translations with BaseTranslations<AppLocale, Translations> {
   String notificationMedicationReminderBodyWeekday({required Object weekday}) =>
       'Scheduled for ${weekday}';
 
+  /// en: 'Take'
+  String get notificationActionTake => 'Take';
+
   /// en: 'Add a schedule'
   String get addSchedule => 'Add a schedule';
 
@@ -1086,6 +1089,7 @@ extension on Translations {
           'Scheduled for ${time}',
       'notificationMedicationReminderBodyWeekday' =>
         ({required Object weekday}) => 'Scheduled for ${weekday}',
+      'notificationActionTake' => 'Take',
       'addSchedule' => 'Add a schedule',
       'addScheduleToGetStarted' => 'Add a schedule to get started.',
       'newSchedule' => 'New schedule',

--- a/lib/i18n/translations_en.g.dart
+++ b/lib/i18n/translations_en.g.dart
@@ -319,6 +319,10 @@ class Translations with BaseTranslations<AppLocale, Translations> {
   /// en: 'Take'
   String get notificationActionTake => 'Take';
 
+  /// en: 'In {minutes}m'
+  String notificationActionSnooze({required Object minutes}) =>
+      'In ${minutes}m';
+
   /// en: 'Add a schedule'
   String get addSchedule => 'Add a schedule';
 
@@ -1090,6 +1094,8 @@ extension on Translations {
       'notificationMedicationReminderBodyWeekday' =>
         ({required Object weekday}) => 'Scheduled for ${weekday}',
       'notificationActionTake' => 'Take',
+      'notificationActionSnooze' => ({required Object minutes}) =>
+          'In ${minutes}m',
       'addSchedule' => 'Add a schedule',
       'addScheduleToGetStarted' => 'Add a schedule to get started.',
       'newSchedule' => 'New schedule',

--- a/lib/i18n/translations_fr.g.dart
+++ b/lib/i18n/translations_fr.g.dart
@@ -614,6 +614,7 @@ class TranslationsFr extends Translations
       (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('fr'))(
         count,
         one: '1 jour sous THS',
+        many: '${count} de jours sous THS',
         other: '${count} jours sous THS',
       );
   @override
@@ -621,6 +622,7 @@ class TranslationsFr extends Translations
       (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('fr'))(
         count,
         one: '1 semaine sous THS',
+        many: '${count} de semaines sous THS',
         other: '${count} semaines sous THS',
       );
   @override
@@ -628,6 +630,7 @@ class TranslationsFr extends Translations
       (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('fr'))(
         count,
         one: '1 mois sous THS',
+        many: '${count} de mois sous THS',
         other: '${count} mois sous THS',
       );
   @override
@@ -635,6 +638,7 @@ class TranslationsFr extends Translations
       (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('fr'))(
         count,
         one: '1 an sous THS',
+        many: '${count} d\'années sous THS',
         other: '${count} ans sous THS',
       );
   @override
@@ -642,6 +646,7 @@ class TranslationsFr extends Translations
       (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('fr'))(
         count,
         one: '1 prise enregistrée',
+        many: '${count} de prises enregistrées',
         other: '${count} prises enregistrées',
       );
   @override
@@ -1072,30 +1077,35 @@ extension on TranslationsFr {
           (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('fr'))(
             count,
             one: '1 jour sous THS',
+            many: '${count} de jours sous THS',
             other: '${count} jours sous THS',
           ),
       'onHrtForWeeks' => ({required num count}) =>
           (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('fr'))(
             count,
             one: '1 semaine sous THS',
+            many: '${count} de semaines sous THS',
             other: '${count} semaines sous THS',
           ),
       'onHrtForMonths' => ({required num count}) =>
           (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('fr'))(
             count,
             one: '1 mois sous THS',
+            many: '${count} de mois sous THS',
             other: '${count} mois sous THS',
           ),
       'onHrtForYears' => ({required num count}) =>
           (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('fr'))(
             count,
             one: '1 an sous THS',
+            many: '${count} d\'années sous THS',
             other: '${count} ans sous THS',
           ),
       'intakesLoggedCount' => ({required num count}) =>
           (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('fr'))(
             count,
             one: '1 prise enregistrée',
+            many: '${count} de prises enregistrées',
             other: '${count} prises enregistrées',
           ),
       'remaining' => ({required num count, required Object unit}) =>

--- a/lib/i18n/translations_nl.g.dart
+++ b/lib/i18n/translations_nl.g.dart
@@ -59,6 +59,266 @@ class TranslationsNl extends Translations
   String get nav_home => 'Mona';
   @override
   String get nav_intakes => 'Innamens';
+  @override
+  String get nav_levels => 'Waarden';
+  @override
+  String get nav_supplies => 'Middelen';
+  @override
+  String get takeAnIntake => 'Dosis toevoegen';
+  @override
+  String get addAnItem => 'Item toevoegen';
+  @override
+  String get empty_home =>
+      'Begin door een planning toe te voegen in de Instellingen';
+  @override
+  String get allDone => 'Afgerond!';
+  @override
+  String get noIntakesDue => 'Geen innamens voor vandaag';
+  @override
+  String get upcoming => 'Aankomend';
+  @override
+  String get taken => 'Genomen';
+  @override
+  String get yesterday => 'gisteren';
+  @override
+  String get tomorrow => 'morgen';
+  @override
+  String get scheduleFrequencyDaily => 'Elke dag';
+  @override
+  String get scheduleFrequencyWeekly => 'Wekelijks';
+  @override
+  String get scheduleFrequencyMonthly => 'Maandelijks';
+  @override
+  String get newUpdateAvailable => 'Een nieuwe update is beschikbaar!';
+  @override
+  String get goToSettings => 'Ga naar Instellingen';
+  @override
+  String get settingsTitle => 'Instellingen';
+  @override
+  String get notifications => 'Meldingen';
+  @override
+  String get schedulesAndNotifications => 'Planning & meldingen';
+  @override
+  String get general => 'Algemeen';
+  @override
+  String get schedules => 'Planning';
+  @override
+  String get noSchedules => 'Geen geplande momenten';
+  @override
+  String get language => 'Taal';
+  @override
+  String get languageFollowDevice => 'Apparaattaal volgen';
+  @override
+  String get selectLanguage => 'Taal Selecteren';
+  @override
+  String get enableNotifications => 'Meldingen aanzetten';
+  @override
+  String get enableNotificationsDescription => 'Reminders verzenden';
+  @override
+  String get notificationsDisabledTitle => 'Meldingen staan uit';
+  @override
+  String get clickToOpenSettings => 'Klik om instellingen te openen';
+  @override
+  String get exactRemindersDisabled => 'Exacte tijden voor reminders staan uit';
+  @override
+  String get remindersDelayed =>
+      'Reminders kunnen misschien een beetje later aankomen. Klik om instellingen te openen.';
+  @override
+  String get medicalSettings => 'Medische instellingen';
+  @override
+  String get theme => 'Thema';
+  @override
+  String get themeCustomizeColors => 'Appkleuren aanpassen';
+  @override
+  String get customThemeEnabled => 'Aangepast thema';
+  @override
+  String get themeGenerate => 'Genereer';
+  @override
+  String get themeVariant => 'Variant';
+  @override
+  String get themeContrast => 'Contrast';
+  @override
+  String get themeContrastStandard => 'Standaard';
+  @override
+  String get themeContrastMedium => 'Medium';
+  @override
+  String get themeContrastHigh => 'Hoog';
+  @override
+  String get autoUpdate => 'Automatisch Updaten';
+  @override
+  String get autoUpdateDescription =>
+      'Check automatisch of er een nieuwe app versie is wanneer de app opstart';
+  @override
+  String get checkForUpdates => 'Check voor Updates';
+  @override
+  String get checkForUpdatesDescription =>
+      'Handmatig controleren op de nieuwste versie\nEr wordt verbinding gemaakt met het internet\n(Er worden geen gegevens verzonden)';
+  @override
+  String appVersion({required Object version}) => 'Mona versie ${version}';
+  @override
+  String backupSavedTo({required Object path}) =>
+      'Backup opgeslagen in: ${path}';
+  @override
+  String exportFailed({required Object error}) =>
+      'Exporteren mislukt: ${error}';
+  @override
+  String get importDataTitle => 'Data importeren';
+  @override
+  String get importDataSubtitle => 'Data herstellen van een JSON backup';
+  @override
+  String get importDataOverwriteWarning =>
+      'Dit zal je oude data overschrijven met de backup. Deze actie kan niet teruggedraaid worden. Wil je toch doorgaan?';
+  @override
+  String get importConfirm => 'Importeren';
+  @override
+  String get importSuccessfulTitle => 'Succesvol geimporteerd';
+  @override
+  String get importRestartRequired =>
+      'Start de app opnieuw op om de nieuwe data in te laden.';
+  @override
+  String get closeApp => 'App Afsluiten';
+  @override
+  String importFailed({required Object error}) =>
+      'Importeren mislukt: ${error}';
+  @override
+  String get updates => 'Updates';
+  @override
+  String get dataManagement => 'Data Management';
+  @override
+  String get exportDataTitle => 'Data Exporteren';
+  @override
+  String get exportDataSubtitle => 'Sla je data op in een JSON bestand';
+  @override
+  String get units => 'Eenheden';
+  @override
+  String get updateNoCompatibleApk =>
+      'Er is geen geschikte update beschikbaar voor je apparaat.';
+  @override
+  String get updateAppUpToDate => 'Je gebruikt de nieuwste versie van de app!';
+  @override
+  String get updateCheckNetworkError =>
+      'Kan niet op nieuwe updates checken op dit moment.';
+  @override
+  String get updateDialogTitle => 'Update Beschikbaar';
+  @override
+  String updateDialogBody({required Object latest, required Object current}) =>
+      'Versie ${latest} is beschikbaar! (Huidige: ${current})\n\nEen geschikte update is klaar om te installeren voor je apparaat.';
+  @override
+  String get updateDownloadAndInstall => 'Download & Installeer';
+  @override
+  String get updateInstallPermissionRequired =>
+      'Een permissie is nodig om updates te kunnen installeren.';
+  @override
+  String get updateDownloadingTitle => 'Update Downloaden...';
+  @override
+  String updateFailedOpenInstaller({required Object message}) =>
+      'Openen van de installer mislukt: ${message}';
+  @override
+  String get updateDownloadFailed =>
+      'Download mislukt. Controlleer je internet connectie.';
+  @override
+  String notificationMedicationReminderBodyDate({required Object date}) =>
+      'Gepland voor ${date}';
+  @override
+  String notificationMedicationReminderBodyTime({required Object time}) =>
+      'Gepland voor ${time}';
+  @override
+  String notificationMedicationReminderBodyWeekday({required Object weekday}) =>
+      'Gepland voor ${weekday}';
+  @override
+  String get addSchedule => 'Planning toevoegen';
+  @override
+  String get addScheduleToGetStarted => 'Voeg een planning toe om te beginnen.';
+  @override
+  String get newSchedule => 'Nieuwe planning';
+  @override
+  String get every => 'Elke';
+  @override
+  String get days => 'dagen';
+  @override
+  String get dayOfMonth => 'Dag van de maand';
+  @override
+  String get months => 'maanden';
+  @override
+  String get startDate => 'Start datun';
+  @override
+  String get pickATime => 'Kies een tijd';
+  @override
+  String get addIntakeTime => 'Een tijd toevoegen';
+  @override
+  String get editScheduleInfo => 'Planning informatie bewerken';
+  @override
+  String get scheduling => 'Planning';
+  @override
+  String get editSchedule => 'Planning bewerken';
+  @override
+  String deleteSchedule({required Object name}) => '${name} verwijderen?';
+  @override
+  String get addNotification => 'Melding toevoegen';
+  @override
+  String daysAgoCount({required num count}) =>
+      (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+        count,
+        one: '${count} dag geleden',
+        other: '${count} dagen geleden',
+      );
+  @override
+  String inDaysCount({required num count}) =>
+      (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+        count,
+        one: 'over ${count} dag',
+        other: 'over ${count} dagen',
+      );
+  @override
+  String scheduleFrequencyEveryNDays({required num count}) =>
+      (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+        count,
+        one: 'Elke dag',
+        other: 'Elke ${count} dagen',
+      );
+  @override
+  String scheduleFrequencyOnDayEveryNMonths(
+          {required num count, required Object day}) =>
+      (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+        count,
+        one: 'Dag ${day}, elke maand',
+        other: 'Dag ${day}, elke ${count} maanden',
+      );
+  @override
+  String schedulesCreated({required num count}) =>
+      (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+        count,
+        one: '${count} aangemaakt',
+        other: '${count} aangemaakt',
+      );
+  @override
+  String onHrtForDays({required num count}) =>
+      (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+        count,
+        one: 'Aan HRT voor 1 dag',
+        other: 'Aan HRT voor ${count} dagen',
+      );
+  @override
+  String onHrtForWeeks({required num count}) =>
+      (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+        count,
+        one: 'Aan HRT voor 1 week',
+        other: 'Aan HRT voor ${count} weken',
+      );
+  @override
+  String onHrtForMonths({required num count}) =>
+      (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+        count,
+        one: 'Aan HRT voor 1 maand',
+        other: 'Aan HRT voor ${count} maanden',
+      );
+  @override
+  String onHrtForYears({required num count}) =>
+      (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+        count,
+        one: 'Aan HRT voor 1 jaar',
+        other: 'Aan HRT voor ${count} jaar',
+      );
 }
 
 /// The flat map containing all translations for locale <nl>.
@@ -72,6 +332,169 @@ extension on TranslationsNl {
       'appTitle' => 'Mona',
       'nav_home' => 'Mona',
       'nav_intakes' => 'Innamens',
+      'nav_levels' => 'Waarden',
+      'nav_supplies' => 'Middelen',
+      'takeAnIntake' => 'Dosis toevoegen',
+      'addAnItem' => 'Item toevoegen',
+      'empty_home' =>
+        'Begin door een planning toe te voegen in de Instellingen',
+      'allDone' => 'Afgerond!',
+      'noIntakesDue' => 'Geen innamens voor vandaag',
+      'upcoming' => 'Aankomend',
+      'taken' => 'Genomen',
+      'yesterday' => 'gisteren',
+      'tomorrow' => 'morgen',
+      'scheduleFrequencyDaily' => 'Elke dag',
+      'scheduleFrequencyWeekly' => 'Wekelijks',
+      'scheduleFrequencyMonthly' => 'Maandelijks',
+      'newUpdateAvailable' => 'Een nieuwe update is beschikbaar!',
+      'goToSettings' => 'Ga naar Instellingen',
+      'settingsTitle' => 'Instellingen',
+      'notifications' => 'Meldingen',
+      'schedulesAndNotifications' => 'Planning & meldingen',
+      'general' => 'Algemeen',
+      'schedules' => 'Planning',
+      'noSchedules' => 'Geen geplande momenten',
+      'language' => 'Taal',
+      'languageFollowDevice' => 'Apparaattaal volgen',
+      'selectLanguage' => 'Taal Selecteren',
+      'enableNotifications' => 'Meldingen aanzetten',
+      'enableNotificationsDescription' => 'Reminders verzenden',
+      'notificationsDisabledTitle' => 'Meldingen staan uit',
+      'clickToOpenSettings' => 'Klik om instellingen te openen',
+      'exactRemindersDisabled' => 'Exacte tijden voor reminders staan uit',
+      'remindersDelayed' =>
+        'Reminders kunnen misschien een beetje later aankomen. Klik om instellingen te openen.',
+      'medicalSettings' => 'Medische instellingen',
+      'theme' => 'Thema',
+      'themeCustomizeColors' => 'Appkleuren aanpassen',
+      'customThemeEnabled' => 'Aangepast thema',
+      'themeGenerate' => 'Genereer',
+      'themeVariant' => 'Variant',
+      'themeContrast' => 'Contrast',
+      'themeContrastStandard' => 'Standaard',
+      'themeContrastMedium' => 'Medium',
+      'themeContrastHigh' => 'Hoog',
+      'autoUpdate' => 'Automatisch Updaten',
+      'autoUpdateDescription' =>
+        'Check automatisch of er een nieuwe app versie is wanneer de app opstart',
+      'checkForUpdates' => 'Check voor Updates',
+      'checkForUpdatesDescription' =>
+        'Handmatig controleren op de nieuwste versie\nEr wordt verbinding gemaakt met het internet\n(Er worden geen gegevens verzonden)',
+      'appVersion' => ({required Object version}) => 'Mona versie ${version}',
+      'backupSavedTo' => ({required Object path}) =>
+          'Backup opgeslagen in: ${path}',
+      'exportFailed' => ({required Object error}) =>
+          'Exporteren mislukt: ${error}',
+      'importDataTitle' => 'Data importeren',
+      'importDataSubtitle' => 'Data herstellen van een JSON backup',
+      'importDataOverwriteWarning' =>
+        'Dit zal je oude data overschrijven met de backup. Deze actie kan niet teruggedraaid worden. Wil je toch doorgaan?',
+      'importConfirm' => 'Importeren',
+      'importSuccessfulTitle' => 'Succesvol geimporteerd',
+      'importRestartRequired' =>
+        'Start de app opnieuw op om de nieuwe data in te laden.',
+      'closeApp' => 'App Afsluiten',
+      'importFailed' => ({required Object error}) =>
+          'Importeren mislukt: ${error}',
+      'updates' => 'Updates',
+      'dataManagement' => 'Data Management',
+      'exportDataTitle' => 'Data Exporteren',
+      'exportDataSubtitle' => 'Sla je data op in een JSON bestand',
+      'units' => 'Eenheden',
+      'updateNoCompatibleApk' =>
+        'Er is geen geschikte update beschikbaar voor je apparaat.',
+      'updateAppUpToDate' => 'Je gebruikt de nieuwste versie van de app!',
+      'updateCheckNetworkError' =>
+        'Kan niet op nieuwe updates checken op dit moment.',
+      'updateDialogTitle' => 'Update Beschikbaar',
+      'updateDialogBody' => (
+              {required Object latest, required Object current}) =>
+          'Versie ${latest} is beschikbaar! (Huidige: ${current})\n\nEen geschikte update is klaar om te installeren voor je apparaat.',
+      'updateDownloadAndInstall' => 'Download & Installeer',
+      'updateInstallPermissionRequired' =>
+        'Een permissie is nodig om updates te kunnen installeren.',
+      'updateDownloadingTitle' => 'Update Downloaden...',
+      'updateFailedOpenInstaller' => ({required Object message}) =>
+          'Openen van de installer mislukt: ${message}',
+      'updateDownloadFailed' =>
+        'Download mislukt. Controlleer je internet connectie.',
+      'notificationMedicationReminderBodyDate' => ({required Object date}) =>
+          'Gepland voor ${date}',
+      'notificationMedicationReminderBodyTime' => ({required Object time}) =>
+          'Gepland voor ${time}',
+      'notificationMedicationReminderBodyWeekday' =>
+        ({required Object weekday}) => 'Gepland voor ${weekday}',
+      'addSchedule' => 'Planning toevoegen',
+      'addScheduleToGetStarted' => 'Voeg een planning toe om te beginnen.',
+      'newSchedule' => 'Nieuwe planning',
+      'every' => 'Elke',
+      'days' => 'dagen',
+      'dayOfMonth' => 'Dag van de maand',
+      'months' => 'maanden',
+      'startDate' => 'Start datun',
+      'pickATime' => 'Kies een tijd',
+      'addIntakeTime' => 'Een tijd toevoegen',
+      'editScheduleInfo' => 'Planning informatie bewerken',
+      'scheduling' => 'Planning',
+      'editSchedule' => 'Planning bewerken',
+      'deleteSchedule' => ({required Object name}) => '${name} verwijderen?',
+      'addNotification' => 'Melding toevoegen',
+      'daysAgoCount' => ({required num count}) =>
+          (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+            count,
+            one: '${count} dag geleden',
+            other: '${count} dagen geleden',
+          ),
+      'inDaysCount' => ({required num count}) =>
+          (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+            count,
+            one: 'over ${count} dag',
+            other: 'over ${count} dagen',
+          ),
+      'scheduleFrequencyEveryNDays' => ({required num count}) =>
+          (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+            count,
+            one: 'Elke dag',
+            other: 'Elke ${count} dagen',
+          ),
+      'scheduleFrequencyOnDayEveryNMonths' => (
+              {required num count, required Object day}) =>
+          (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+            count,
+            one: 'Dag ${day}, elke maand',
+            other: 'Dag ${day}, elke ${count} maanden',
+          ),
+      'schedulesCreated' => ({required num count}) =>
+          (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+            count,
+            one: '${count} aangemaakt',
+            other: '${count} aangemaakt',
+          ),
+      'onHrtForDays' => ({required num count}) =>
+          (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+            count,
+            one: 'Aan HRT voor 1 dag',
+            other: 'Aan HRT voor ${count} dagen',
+          ),
+      'onHrtForWeeks' => ({required num count}) =>
+          (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+            count,
+            one: 'Aan HRT voor 1 week',
+            other: 'Aan HRT voor ${count} weken',
+          ),
+      'onHrtForMonths' => ({required num count}) =>
+          (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+            count,
+            one: 'Aan HRT voor 1 maand',
+            other: 'Aan HRT voor ${count} maanden',
+          ),
+      'onHrtForYears' => ({required num count}) =>
+          (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('nl'))(
+            count,
+            one: 'Aan HRT voor 1 jaar',
+            other: 'Aan HRT voor ${count} jaar',
+          ),
       _ => null,
     };
   }

--- a/lib/services/notification_action_handler.dart
+++ b/lib/services/notification_action_handler.dart
@@ -1,0 +1,96 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_timezone/flutter_timezone.dart';
+import 'package:mona/data/model/medication_intake.dart';
+import 'package:mona/data/model/medication_schedule.dart';
+import 'package:mona/data/providers/medication_intake_provider.dart';
+import 'package:mona/data/providers/medication_schedule_provider.dart';
+import 'package:mona/services/notification_service.dart';
+import 'package:mona/services/repository.dart';
+
+/// Handles the "Take" notification action (see [takeActionId]): logs an
+/// intake for the reminder's schedule directly, without opening the app.
+///
+/// Runs on a separate background isolate the OS spawns just for this call,
+/// so there's no running app, no Provider tree, nothing already in memory.
+/// It talks to the database directly through the same repositories
+/// [MedicationIntakeProvider]/[MedicationScheduleProvider] use, bypassing
+/// the ChangeNotifier wrappers themselves since there's nothing here to
+/// notify and their async init-then-read pattern assumes a widget tree.
+///
+/// Deliberately narrow in scope: no supply item is linked/deducted (there's
+/// no sensible way to guess which one headlessly) and nothing else that
+/// depends on the app already running (widget/notification resync) happens
+/// here -- that catches up next time the app is opened, same as it already
+/// does for other changes made while the app isn't running.
+///
+/// Must be a top-level function annotated with `@pragma('vm:entry-point')`
+/// so the Dart compiler doesn't strip it and the background isolate can
+/// find it by name, see flutter_local_notifications' background response
+/// docs.
+///
+/// [scheduleRepository]/[intakeRepository] default to the app's real
+/// sqflite-backed repositories; overridable for tests. Extra optional
+/// params are fine on a callback passed as
+/// `onDidReceiveBackgroundNotificationResponse` -- Dart's function
+/// subtyping allows them.
+@pragma('vm:entry-point')
+Future<void> onBackgroundNotificationResponse(
+  NotificationResponse response, {
+  Repository<MedicationSchedule>? scheduleRepository,
+  Repository<MedicationIntake>? intakeRepository,
+}) async {
+  if (response.actionId != takeActionId) return;
+
+  final payload = _decodePayload(response.payload);
+  final scheduleId = payload['scheduleId'] as int?;
+  if (scheduleId == null) return;
+
+  WidgetsFlutterBinding.ensureInitialized();
+
+  final schedules =
+      await (scheduleRepository ?? MedicationScheduleProvider.defaultRepository)
+          .getAll();
+  MedicationSchedule? schedule;
+  for (final s in schedules) {
+    if (s.id == scheduleId) {
+      schedule = s;
+      break;
+    }
+  }
+  if (schedule == null) return;
+
+  final scheduledTime = _scheduledTimeFrom(payload);
+  final timezone = await FlutterTimezone.getLocalTimezone();
+
+  await (intakeRepository ?? MedicationIntakeProvider.defaultRepository)
+      .insert(MedicationIntake(
+    takenDose: schedule.dose,
+    scheduledTime: scheduledTime,
+    takenDateTime: DateTime.now().toUtc(),
+    takenTimeZone: timezone.identifier,
+    scheduleId: schedule.id,
+    molecule: schedule.molecule,
+    administrationRoute: schedule.administrationRoute,
+    ester: schedule.ester,
+  ));
+}
+
+Map<String, dynamic> _decodePayload(String? payload) {
+  if (payload == null || payload.isEmpty) return {};
+  try {
+    final decoded = jsonDecode(payload);
+    return decoded is Map<String, dynamic> ? decoded : {};
+  } catch (_) {
+    return {};
+  }
+}
+
+TimeOfDay? _scheduledTimeFrom(Map<String, dynamic> payload) {
+  final hour = payload['scheduledTimeHour'] as int?;
+  final minute = payload['scheduledTimeMinute'] as int?;
+  if (hour == null || minute == null) return null;
+  return TimeOfDay(hour: hour, minute: minute);
+}

--- a/lib/services/notification_action_handler.dart
+++ b/lib/services/notification_action_handler.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_timezone/flutter_timezone.dart';
@@ -10,21 +11,11 @@ import 'package:mona/data/providers/medication_schedule_provider.dart';
 import 'package:mona/services/notification_service.dart';
 import 'package:mona/services/repository.dart';
 
-/// Handles the "Take" notification action (see [takeActionId]): logs an
-/// intake for the reminder's schedule directly, without opening the app.
+/// Handles medication reminder notification actions -- "Take" ([takeActionId])
+/// and "Snooze" ([snoozeActionId]) -- without opening the app.
 ///
 /// Runs on a separate background isolate the OS spawns just for this call,
 /// so there's no running app, no Provider tree, nothing already in memory.
-/// It talks to the database directly through the same repositories
-/// [MedicationIntakeProvider]/[MedicationScheduleProvider] use, bypassing
-/// the ChangeNotifier wrappers themselves since there's nothing here to
-/// notify and their async init-then-read pattern assumes a widget tree.
-///
-/// Deliberately narrow in scope: no supply item is linked/deducted (there's
-/// no sensible way to guess which one headlessly) and nothing else that
-/// depends on the app already running (widget/notification resync) happens
-/// here -- that catches up next time the app is opened, same as it already
-/// does for other changes made while the app isn't running.
 ///
 /// Must be a top-level function annotated with `@pragma('vm:entry-point')`
 /// so the Dart compiler doesn't strip it and the background isolate can
@@ -42,9 +33,36 @@ Future<void> onBackgroundNotificationResponse(
   Repository<MedicationSchedule>? scheduleRepository,
   Repository<MedicationIntake>? intakeRepository,
 }) async {
-  if (response.actionId != takeActionId) return;
-
   final payload = _decodePayload(response.payload);
+
+  switch (response.actionId) {
+    case takeActionId:
+      await _handleTake(
+        payload,
+        scheduleRepository: scheduleRepository,
+        intakeRepository: intakeRepository,
+      );
+    case snoozeActionId:
+      await _handleSnooze(payload);
+  }
+}
+
+/// Logs an intake for the reminder's schedule directly. It talks to the
+/// database through the same repositories [MedicationIntakeProvider]/
+/// [MedicationScheduleProvider] use, bypassing the ChangeNotifier wrappers
+/// themselves since there's nothing here to notify and their async
+/// init-then-read pattern assumes a widget tree.
+///
+/// Deliberately narrow in scope: no supply item is linked/deducted (there's
+/// no sensible way to guess which one headlessly) and nothing else that
+/// depends on the app already running (widget/notification resync) happens
+/// here -- that catches up next time the app is opened, same as it already
+/// does for other changes made while the app isn't running.
+Future<void> _handleTake(
+  Map<String, dynamic> payload, {
+  Repository<MedicationSchedule>? scheduleRepository,
+  Repository<MedicationIntake>? intakeRepository,
+}) async {
   final scheduleId = payload['scheduleId'] as int?;
   if (scheduleId == null) return;
 
@@ -76,6 +94,38 @@ Future<void> onBackgroundNotificationResponse(
     administrationRoute: schedule.administrationRoute,
     ester: schedule.ester,
   ));
+}
+
+/// Reschedules the exact same reminder [snoozeDuration] later, reusing the
+/// original (already-localized) title/body text carried in the payload
+/// rather than re-rendering strings from a background isolate that has no
+/// guarantee of running with the user's chosen locale.
+///
+/// No database read needed: unlike [_handleTake], nothing here depends on
+/// the schedule's current state, just the id/time-of-day to carry forward
+/// so the snoozed notification's own Take/Snooze actions keep working (and
+/// can themselves be snoozed again).
+Future<void> _handleSnooze(Map<String, dynamic> payload) async {
+  final scheduleId = payload['scheduleId'] as int?;
+  final title = payload['title'] as String?;
+  final body = payload['body'] as String?;
+  if (scheduleId == null || title == null || body == null) return;
+
+  WidgetsFlutterBinding.ensureInitialized();
+  await NotificationService().initialize();
+
+  final scheduledTime = clock.now().add(snoozeDuration);
+
+  await NotificationService().scheduleNotification(
+    id: Object.hash(scheduleId, scheduledTime.millisecondsSinceEpoch) &
+        0x7fffffff,
+    title: title,
+    body: body,
+    scheduledTime: scheduledTime,
+    scheduleId: scheduleId,
+    scheduledTimeHour: payload['scheduledTimeHour'] as int?,
+    scheduledTimeMinute: payload['scheduledTimeMinute'] as int?,
+  );
 }
 
 Map<String, dynamic> _decodePayload(String? payload) {

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -15,6 +15,13 @@ import 'package:timezone/timezone.dart' as tz;
 /// see lib/services/notification_action_handler.dart.
 const String takeActionId = 'take';
 
+/// Id of the notification action that reschedules the same reminder
+/// [snoozeDuration] later instead of logging it. Shared with the
+/// background handler.
+const String snoozeActionId = 'snooze';
+
+const Duration snoozeDuration = Duration(minutes: 30);
+
 class NotificationService {
   static FlutterLocalNotificationsPlugin Function()? createPlugin =
       () => FlutterLocalNotificationsPlugin();
@@ -88,6 +95,12 @@ class NotificationService {
             takeActionId,
             t.notificationActionTake,
             // Runs the background handler directly, no app UI shown.
+            showsUserInterface: false,
+            cancelNotification: true,
+          ),
+          AndroidNotificationAction(
+            snoozeActionId,
+            t.notificationActionSnooze(minutes: snoozeDuration.inMinutes),
             showsUserInterface: false,
             cancelNotification: true,
           ),
@@ -248,6 +261,12 @@ class NotificationService {
       if (scheduledTimeHour != null) 'scheduledTimeHour': scheduledTimeHour,
       if (scheduledTimeMinute != null)
         'scheduledTimeMinute': scheduledTimeMinute,
+      // Carried along so the "Snooze" action (see [snoozeActionId]) can
+      // reschedule with the exact same, already-localized text without
+      // needing to re-render strings from a background isolate that has
+      // no guarantee of running with the user's chosen locale.
+      'title': title,
+      'body': body,
     });
     final dateTime = tz.TZDateTime(
         tz.local,

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -5,9 +5,15 @@ import 'package:clock/clock.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_timezone/flutter_timezone.dart';
+import 'package:mona/i18n/translations.g.dart';
 import 'package:mona/util/string_parsing.dart';
 import 'package:timezone/data/latest_all.dart' as tzdata;
 import 'package:timezone/timezone.dart' as tz;
+
+/// Id of the notification action that logs an intake as taken without
+/// opening the app. Shared with the background handler that processes it,
+/// see lib/services/notification_action_handler.dart.
+const String takeActionId = 'take';
 
 class NotificationService {
   static FlutterLocalNotificationsPlugin Function()? createPlugin =
@@ -35,7 +41,11 @@ class NotificationService {
       _notificationsPlugin.resolvePlatformSpecificImplementation<
           IOSFlutterLocalNotificationsPlugin>();
 
-  Future<void> initialize() async {
+  Future<void> initialize({
+    DidReceiveNotificationResponseCallback? onDidReceiveNotificationResponse,
+    DidReceiveBackgroundNotificationResponseCallback?
+        onDidReceiveBackgroundNotificationResponse,
+  }) async {
     if (_initialized) return;
 
     tzdata.initializeTimeZones();
@@ -53,22 +63,37 @@ class NotificationService {
     );
 
     await _notificationsPlugin.initialize(
-        settings: InitializationSettings(
-      android: androidSettings,
-      iOS: iosSettings,
-    ));
+      settings: InitializationSettings(
+        android: androidSettings,
+        iOS: iosSettings,
+      ),
+      onDidReceiveNotificationResponse: onDidReceiveNotificationResponse,
+      onDidReceiveBackgroundNotificationResponse:
+          onDidReceiveBackgroundNotificationResponse,
+    );
 
     _initialized = true;
   }
 
   NotificationDetails _notificationDetails() {
-    return const NotificationDetails(
+    return NotificationDetails(
       android: AndroidNotificationDetails(
-          'medication_intakes', 'Medication Intakes',
-          channelDescription: 'Notifications for medication intakes',
-          importance: Importance.max,
-          priority: Priority.max),
-      iOS: DarwinNotificationDetails(
+        'medication_intakes',
+        'Medication Intakes',
+        channelDescription: 'Notifications for medication intakes',
+        importance: Importance.max,
+        priority: Priority.max,
+        actions: [
+          AndroidNotificationAction(
+            takeActionId,
+            t.notificationActionTake,
+            // Runs the background handler directly, no app UI shown.
+            showsUserInterface: false,
+            cancelNotification: true,
+          ),
+        ],
+      ),
+      iOS: const DarwinNotificationDetails(
         interruptionLevel: InterruptionLevel.timeSensitive,
         presentAlert: true,
         presentBadge: true,
@@ -122,6 +147,7 @@ class NotificationService {
     int? id,
     String? title,
     String? body,
+    String? payload,
   }) async {
     id ??= Random().nextInt(1 << 31);
 
@@ -137,20 +163,32 @@ class NotificationService {
       title: title,
       body: body,
       notificationDetails: _notificationDetails(),
+      payload: payload,
     );
   }
 
+  /// [scheduleId] is embedded in the payload so the "Take" action (see
+  /// [takeActionId]) knows which schedule to log an intake for.
+  /// [scheduledTimeHour]/[scheduledTimeMinute] are only meaningful (and
+  /// only need setting) for daily/weekly schedules, where MedicationIntake
+  /// tracks which time-of-day slot was taken.
   Future<void> scheduleNotification({
     required int id,
     required String title,
     required String body,
     required DateTime scheduledTime,
+    required int scheduleId,
+    int? scheduledTimeHour,
+    int? scheduledTimeMinute,
   }) =>
       _schedule(
         id: id,
         title: title,
         body: body,
         scheduledTime: scheduledTime,
+        scheduleId: scheduleId,
+        scheduledTimeHour: scheduledTimeHour,
+        scheduledTimeMinute: scheduledTimeMinute,
       );
 
   Future<void> scheduleDailyNotification({
@@ -158,6 +196,9 @@ class NotificationService {
     required String title,
     required String body,
     required DateTime firstOccurrence,
+    required int scheduleId,
+    int? scheduledTimeHour,
+    int? scheduledTimeMinute,
   }) =>
       _schedule(
         id: id,
@@ -165,6 +206,9 @@ class NotificationService {
         body: body,
         scheduledTime: firstOccurrence,
         matchComponents: DateTimeComponents.time,
+        scheduleId: scheduleId,
+        scheduledTimeHour: scheduledTimeHour,
+        scheduledTimeMinute: scheduledTimeMinute,
       );
 
   Future<void> scheduleWeeklyNotification({
@@ -172,6 +216,9 @@ class NotificationService {
     required String title,
     required String body,
     required DateTime firstOccurrence,
+    required int scheduleId,
+    int? scheduledTimeHour,
+    int? scheduledTimeMinute,
   }) =>
       _schedule(
         id: id,
@@ -179,6 +226,9 @@ class NotificationService {
         body: body,
         scheduledTime: firstOccurrence,
         matchComponents: DateTimeComponents.dayOfWeekAndTime,
+        scheduleId: scheduleId,
+        scheduledTimeHour: scheduledTimeHour,
+        scheduledTimeMinute: scheduledTimeMinute,
       );
 
   Future<void> _schedule({
@@ -186,11 +236,18 @@ class NotificationService {
     required String title,
     required String body,
     required DateTime scheduledTime,
+    required int scheduleId,
     DateTimeComponents? matchComponents,
+    int? scheduledTimeHour,
+    int? scheduledTimeMinute,
   }) async {
     final payload = jsonEncode({
       'scheduledTime': scheduledTime.toIso8601String(),
       if (matchComponents != null) 'isRepeating': true,
+      'scheduleId': scheduleId,
+      if (scheduledTimeHour != null) 'scheduledTimeHour': scheduledTimeHour,
+      if (scheduledTimeMinute != null)
+        'scheduledTimeMinute': scheduledTimeMinute,
     });
     final dateTime = tz.TZDateTime(
         tz.local,
@@ -245,6 +302,7 @@ class NotificationService {
       await showNotification(
         title: notification.title,
         body: notification.body,
+        payload: notification.payload,
       );
     }
   }

--- a/test/services/notification_action_handler_test.dart
+++ b/test/services/notification_action_handler_test.dart
@@ -1,0 +1,127 @@
+import 'dart:convert';
+
+import 'package:decimal/decimal.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mona/data/model/administration_route.dart';
+import 'package:mona/data/model/medication_intake.dart';
+import 'package:mona/data/model/medication_schedule.dart';
+import 'package:mona/data/model/molecule.dart';
+import 'package:mona/data/model/scheduling_strategy.dart';
+import 'package:mona/services/notification_action_handler.dart';
+import 'package:mona/services/notification_service.dart';
+
+import '../data/providers/generic_repository_mock.dart';
+
+NotificationResponse _response({String? actionId, String? payload}) {
+  return NotificationResponse(
+    notificationResponseType:
+        NotificationResponseType.selectedNotificationAction,
+    actionId: actionId,
+    payload: payload,
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(
+    const MethodChannel('flutter_timezone'),
+    (MethodCall call) async {
+      if (call.method == 'getLocalTimezone') return 'UTC';
+      return null;
+    },
+  );
+
+  late GenericRepositoryMock<MedicationSchedule> scheduleRepository;
+  late GenericRepositoryMock<MedicationIntake> intakeRepository;
+
+  setUp(() {
+    scheduleRepository = GenericRepositoryMock<MedicationSchedule>(
+      withId: (i, id) => MedicationSchedule(
+        id: id,
+        name: i.name,
+        dose: i.dose,
+        scheduling: i.scheduling,
+        molecule: i.molecule,
+        administrationRoute: i.administrationRoute,
+        ester: i.ester,
+      ),
+    );
+    intakeRepository = GenericRepositoryMock<MedicationIntake>(
+      withId: (i, id) => i.copyWith(id: id),
+    );
+
+    scheduleRepository.insert(MedicationSchedule(
+      id: 1,
+      name: 'Estradiol',
+      dose: Decimal.parse('2.0'),
+      scheduling: IntervalDaysSchedule(intervalDays: 1),
+      molecule: KnownMolecules.estradiol,
+      administrationRoute: AdministrationRoute.oral,
+    ));
+  });
+
+  Future<void> handle(NotificationResponse response) =>
+      onBackgroundNotificationResponse(
+        response,
+        scheduleRepository: scheduleRepository,
+        intakeRepository: intakeRepository,
+      );
+
+  test('ignores responses for other actions', () async {
+    await handle(_response(
+      actionId: 'something_else',
+      payload: jsonEncode({'scheduleId': 1}),
+    ));
+
+    expect(intakeRepository.items, isEmpty);
+  });
+
+  test('ignores a payload with no scheduleId', () async {
+    await handle(_response(actionId: takeActionId, payload: null));
+
+    expect(intakeRepository.items, isEmpty);
+  });
+
+  test('ignores a scheduleId that no longer exists', () async {
+    await handle(_response(
+      actionId: takeActionId,
+      payload: jsonEncode({'scheduleId': 999}),
+    ));
+
+    expect(intakeRepository.items, isEmpty);
+  });
+
+  test('logs an intake matching the schedule', () async {
+    await handle(_response(
+      actionId: takeActionId,
+      payload: jsonEncode({'scheduleId': 1}),
+    ));
+
+    final intake = intakeRepository.items.single;
+    expect(intake.scheduleId, 1);
+    expect(intake.takenDose, Decimal.parse('2.0'));
+    expect(intake.molecule, KnownMolecules.estradiol);
+    expect(intake.administrationRoute, AdministrationRoute.oral);
+    expect(intake.isTaken, true);
+    expect(intake.scheduledTime, isNull);
+  });
+
+  test('carries the scheduled time-of-day for daily/weekly reminders',
+      () async {
+    await handle(_response(
+      actionId: takeActionId,
+      payload: jsonEncode({
+        'scheduleId': 1,
+        'scheduledTimeHour': 8,
+        'scheduledTimeMinute': 30,
+      }),
+    ));
+
+    final intake = intakeRepository.items.single;
+    expect(intake.scheduledTime?.hour, 8);
+    expect(intake.scheduledTime?.minute, 30);
+  });
+}

--- a/test/services/notification_action_handler_test.dart
+++ b/test/services/notification_action_handler_test.dart
@@ -11,8 +11,13 @@ import 'package:mona/data/model/molecule.dart';
 import 'package:mona/data/model/scheduling_strategy.dart';
 import 'package:mona/services/notification_action_handler.dart';
 import 'package:mona/services/notification_service.dart';
+import 'package:timezone/data/latest_all.dart' as tzdata;
+import 'package:timezone/timezone.dart' as tz;
 
 import '../data/providers/generic_repository_mock.dart';
+import '../util/test_clock.dart';
+import 'notification_service_test.dart'
+    show FakeFlutterLocalNotificationsPlugin;
 
 NotificationResponse _response({String? actionId, String? payload}) {
   return NotificationResponse(
@@ -33,11 +38,22 @@ void main() {
       return null;
     },
   );
+  tzdata.initializeTimeZones();
+  tz.setLocalLocation(tz.getLocation('Etc/UTC'));
 
   late GenericRepositoryMock<MedicationSchedule> scheduleRepository;
   late GenericRepositoryMock<MedicationIntake> intakeRepository;
+  late FakeFlutterLocalNotificationsPlugin fakePlugin;
+  late bool Function()? origPlatformCheck;
+  late FlutterLocalNotificationsPlugin Function()? origCreatePlugin;
 
   setUp(() {
+    fakePlugin = FakeFlutterLocalNotificationsPlugin();
+    origPlatformCheck = NotificationService.isPlatformSupported;
+    origCreatePlugin = NotificationService.createPlugin;
+    NotificationService.isPlatformSupported = () => true;
+    NotificationService.createPlugin = () => fakePlugin;
+
     scheduleRepository = GenericRepositoryMock<MedicationSchedule>(
       withId: (i, id) => MedicationSchedule(
         id: id,
@@ -61,6 +77,11 @@ void main() {
       molecule: KnownMolecules.estradiol,
       administrationRoute: AdministrationRoute.oral,
     ));
+  });
+
+  tearDown(() {
+    NotificationService.isPlatformSupported = origPlatformCheck;
+    NotificationService.createPlugin = origCreatePlugin;
   });
 
   Future<void> handle(NotificationResponse response) =>
@@ -123,5 +144,82 @@ void main() {
     final intake = intakeRepository.items.single;
     expect(intake.scheduledTime?.hour, 8);
     expect(intake.scheduledTime?.minute, 30);
+  });
+
+  test('snooze does not log an intake', () async {
+    await withFixedClockAsync(() async {
+      await handle(_response(
+        actionId: snoozeActionId,
+        payload: jsonEncode({
+          'scheduleId': 1,
+          'title': 'Time to take Estradiol',
+          'body': 'Scheduled for 8:00 AM',
+        }),
+      ));
+    });
+
+    expect(intakeRepository.items, isEmpty);
+  });
+
+  test('snooze reschedules the same reminder text snoozeDuration later',
+      () async {
+    await withFixedClockAsync(() async {
+      await handle(_response(
+        actionId: snoozeActionId,
+        payload: jsonEncode({
+          'scheduleId': 1,
+          'title': 'Time to take Estradiol',
+          'body': 'Scheduled for 8:00 AM',
+        }),
+      ));
+
+      final n = fakePlugin.scheduled.single;
+      expect(n['title'], 'Time to take Estradiol');
+      expect(n['body'], 'Scheduled for 8:00 AM');
+      final expected = testNow.add(snoozeDuration);
+      final scheduledDate = n['date'] as tz.TZDateTime;
+      expect(scheduledDate.year, expected.year);
+      expect(scheduledDate.month, expected.month);
+      expect(scheduledDate.day, expected.day);
+      expect(scheduledDate.hour, expected.hour);
+      expect(scheduledDate.minute, expected.minute);
+
+      final payload =
+          jsonDecode(n['payload'] as String) as Map<String, Object?>;
+      expect(payload['scheduleId'], 1);
+    });
+  });
+
+  test('snooze carries the scheduled time-of-day forward so it can be taken',
+      () async {
+    await withFixedClockAsync(() async {
+      await handle(_response(
+        actionId: snoozeActionId,
+        payload: jsonEncode({
+          'scheduleId': 1,
+          'title': 'Time to take Estradiol',
+          'body': 'Scheduled for 8:00 AM',
+          'scheduledTimeHour': 8,
+          'scheduledTimeMinute': 0,
+        }),
+      ));
+
+      final n = fakePlugin.scheduled.single;
+      final payload =
+          jsonDecode(n['payload'] as String) as Map<String, Object?>;
+      expect(payload['scheduledTimeHour'], 8);
+      expect(payload['scheduledTimeMinute'], 0);
+    });
+  });
+
+  test('snooze ignores a payload missing title/body', () async {
+    await withFixedClockAsync(() async {
+      await handle(_response(
+        actionId: snoozeActionId,
+        payload: jsonEncode({'scheduleId': 1}),
+      ));
+    });
+
+    expect(fakePlugin.scheduled, isEmpty);
   });
 }

--- a/test/services/notification_service_test.dart
+++ b/test/services/notification_service_test.dart
@@ -168,6 +168,22 @@ void main() {
     expect(payload['scheduleId'], 42);
   });
 
+  test('scheduleNotification embeds title/body in the payload for snoozing',
+      () async {
+    await service.scheduleNotification(
+      id: 1,
+      title: 'Test',
+      body: 'Body',
+      scheduledTime: DateTime(2026, 2, 8, 10, 30),
+      scheduleId: 42,
+    );
+
+    final n = fakePlugin.scheduled.single;
+    final payload = jsonDecode(n['payload'] as String) as Map<String, Object?>;
+    expect(payload['title'], 'Test');
+    expect(payload['body'], 'Body');
+  });
+
   test('showNotification adds a shown notification', () async {
     await service.showNotification(title: 'Show', body: 'Body');
     expect(fakePlugin.shown.length, 1);

--- a/test/services/notification_service_test.dart
+++ b/test/services/notification_service_test.dart
@@ -142,6 +142,7 @@ void main() {
       title: 'Test',
       body: 'Body',
       scheduledTime: DateTime(2026, 2, 8, 10, 30),
+      scheduleId: 42,
     );
 
     expect(fakePlugin.scheduled.length, 1);
@@ -151,6 +152,20 @@ void main() {
     expect(n['body'], 'Body');
     expect((n['date'] as tz.TZDateTime).hour, 10);
     expect((n['date'] as tz.TZDateTime).minute, 30);
+  });
+
+  test('scheduleNotification embeds the scheduleId in the payload', () async {
+    await service.scheduleNotification(
+      id: 1,
+      title: 'Test',
+      body: 'Body',
+      scheduledTime: DateTime(2026, 2, 8, 10, 30),
+      scheduleId: 42,
+    );
+
+    final n = fakePlugin.scheduled.single;
+    final payload = jsonDecode(n['payload'] as String) as Map<String, Object?>;
+    expect(payload['scheduleId'], 42);
   });
 
   test('showNotification adds a shown notification', () async {
@@ -167,6 +182,7 @@ void main() {
       title: 'T1',
       body: 'B1',
       scheduledTime: DateTime(2026, 2, 8, 10, 0),
+      scheduleId: 1,
     );
     await service.cancelAllNotifications();
     expect(fakePlugin.scheduled.length, 0);
@@ -178,12 +194,14 @@ void main() {
       title: 'T1',
       body: 'B1',
       scheduledTime: DateTime(2026, 2, 8, 10, 0),
+      scheduleId: 1,
     );
     await service.scheduleNotification(
       id: 2,
       title: 'T2',
       body: 'B2',
       scheduledTime: DateTime(2026, 2, 9, 10, 0),
+      scheduleId: 2,
     );
 
     await service.cancelPendingNotifications();
@@ -247,6 +265,9 @@ void main() {
       title: 'D',
       body: 'B',
       firstOccurrence: firstFire,
+      scheduleId: 7,
+      scheduledTimeHour: 10,
+      scheduledTimeMinute: 30,
     );
 
     // Assert
@@ -254,6 +275,9 @@ void main() {
     final payload = jsonDecode(n['payload'] as String) as Map<String, Object?>;
     expect(n['matchDateTimeComponents'], DateTimeComponents.time);
     expect(payload['isRepeating'], isTrue);
+    expect(payload['scheduleId'], 7);
+    expect(payload['scheduledTimeHour'], 10);
+    expect(payload['scheduledTimeMinute'], 30);
   });
 
   test(
@@ -268,6 +292,9 @@ void main() {
       title: 'W',
       body: 'B',
       firstOccurrence: firstFire,
+      scheduleId: 9,
+      scheduledTimeHour: 8,
+      scheduledTimeMinute: 0,
     );
 
     // Assert
@@ -275,5 +302,43 @@ void main() {
     final payload = jsonDecode(n['payload'] as String) as Map<String, Object?>;
     expect(n['matchDateTimeComponents'], DateTimeComponents.dayOfWeekAndTime);
     expect(payload['isRepeating'], isTrue);
+    expect(payload['scheduleId'], 9);
+  });
+
+  test('showNotification forwards the payload when provided', () async {
+    await service.showNotification(
+      title: 'Show',
+      body: 'Body',
+      payload: jsonEncode({'scheduleId': 5}),
+    );
+
+    final n = fakePlugin.shown.single;
+    final payload = jsonDecode(n['payload'] as String) as Map<String, Object?>;
+    expect(payload['scheduleId'], 5);
+  });
+
+  test('triggerPastPendingNotifications forwards the original payload',
+      () async {
+    await withFixedClockAsync(() async {
+      final payload = jsonEncode({
+        'scheduledTime':
+            clock.now().subtract(Duration(days: 1)).toIso8601String(),
+        'scheduleId': 3,
+      });
+      fakePlugin.scheduled.add({
+        'id': 1,
+        'title': 'Past',
+        'body': 'B',
+        'date': clock.now(),
+        'payload': payload,
+      });
+
+      await service.triggerPastPendingNotifications();
+
+      final shown = fakePlugin.shown.single;
+      final shownPayload =
+          jsonDecode(shown['payload'] as String) as Map<String, Object?>;
+      expect(shownPayload['scheduleId'], 3);
+    });
   });
 }


### PR DESCRIPTION
### Description

Fixes #245: tapping a button on the reminder notification logs the intake directly, no need to open the app, find the schedule, and tap through to confirm it.

- Notifications get an AndroidNotificationAction (`showsUserInterface: false`, `cancelNotification: true`) so tapping it doesn't open the app, it runs in the background and dismisses itself.
- The schedule id (and time-of-day for daily/weekly reminders) is embedded in the notification payload so the background handler knows which schedule to log against.
- `notification_action_handler.dart` runs on the separate isolate Android spawns for the tap. No running app, no Provider tree at that point, so it reads/writes through the same repositories `MedicationIntakeProvider`/`MedicationScheduleProvider` use directly (made public, same convention `SupplyItemProvider` already had) rather than duplicating table wiring.
- Needed `com.dexterous.flutterlocalnotifications.ActionBroadcastReceiver` declared in AndroidManifest.xml. Without it the action tap is silently swallowed before it ever reaches Dart, confirmed via logcat (no process spawn, no Flutter engine start at all). Easy one to miss if anyone else hits this.

Deliberately narrow in scope for this PR: no supply item is linked/deducted from the background isolate (nothing sensible to guess headlessly), and widgets/notification resync happens next time the app is opened/foregrounded rather than from the isolate itself (added a resync on app resume for that).

Tested end-to-end on a real device: notification renders with the button, tapping it doesn't open the app, and the intake shows up in the Intakes tab afterward.

Related to issue(s): 245

### Type of change

- New feature (non-breaking change which adds functionality)

### Screenshots (if appropriate):

n/a, notification action + background behavior