### PR TITLE
Widget localization bug

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -126,6 +126,13 @@ android {
             resValue 'string', 'app_name', '"Mona"'
         }
     }
+
+    bundle {
+        language {
+            // avoids stripping locales the device is not set to
+            enableSplit = false
+        }
+    }
 }
 
 flutter {

--- a/android/app/src/main/kotlin/com/deliacheminot/mona/HrtGlanceWidget.kt
+++ b/android/app/src/main/kotlin/com/deliacheminot/mona/HrtGlanceWidget.kt
@@ -73,7 +73,8 @@ class HrtGlanceWidget : GlanceAppWidget() {
         val text = if (hasData) {
             durationText(context, firstDate!!, localeTag)
         } else {
-            context.getString(R.string.hrt_home_widget_placeholder)
+            localizedContext(context, localeTag)
+                .getString(R.string.hrt_home_widget_placeholder)
         }
         val widthDp = LocalSize.current.width.value
         val subtitle = if (hasData && intakeCount != null && titleFitsOneLine(context, text, widthDp)) {


### PR DESCRIPTION
- android used to strip languages not selected in device settings when installing from the play store, now prevents that.
- widget placeholder was not using the selected language (only on-device language). fixed.

### Type of change
- Bug fix (non-breaking change which fixes an issue)