### PR TITLE
fix: use correct colors for the supply item picker

### DIFF
--- a/lib/ui/widgets/intake_supply_picker.dart
+++ b/lib/ui/widgets/intake_supply_picker.dart
@@ -74,6 +74,8 @@ class IntakeSupplyPicker extends StatelessWidget {
                 leading: CircleAvatar(
                   backgroundColor:
                       Theme.of(sheetContext).colorScheme.secondaryContainer,
+                  foregroundColor:
+                      Theme.of(sheetContext).colorScheme.onSecondaryContainer,
                   child: Icon(item.genericSupplyType.icon),
                 ),
                 title: Text(item.name),
@@ -85,9 +87,9 @@ class IntakeSupplyPicker extends StatelessWidget {
               ),
             ListTile(
               leading: CircleAvatar(
-                foregroundColor:
-                    Theme.of(sheetContext).colorScheme.tertiaryContainer,
                 backgroundColor:
+                    Theme.of(sheetContext).colorScheme.tertiaryContainer,
+                foregroundColor:
                     Theme.of(sheetContext).colorScheme.onTertiaryContainer,
                 child: Icon(Symbols.add_rounded),
               ),


### PR DESCRIPTION
### Description

fixes this
<img width="590" height="1278" alt="Capture d’écran 2026-08-25 à 23 39 14" src="https://github.com/user-attachments/assets/c0bfc233-c8fe-429f-9865-c4f9703e2088" />

### Type of change
- Bug fix (non-breaking change which fixes an issue)